### PR TITLE
Update unpublish doc to mention 24h re-publish timeout

### DIFF
--- a/content/packages-and-modules/updating-and-managing-your-published-packages/unpublishing-packages-from-the-registry.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/unpublishing-packages-from-the-registry.mdx
@@ -5,10 +5,7 @@ import shared from '../../../src/shared.js'
 
 ## How to unpublish
 
-As a package owner or collaborator, you can permanently remove the package from the npm registry using the CLI. To do so, the following conditions should be met:
-
-* Within the first 72 hours of the initial publish, you can [unpublish][unpublish-cli] provided your package has no dependents.
-* Beyond 72 hours, you can still [unpublish][unpublish-cli] your package if [it meets certain criteria](https://www.npmjs.com/policies/unpublish).
+As a package owner or collaborator, if your package has no dependents, you can permanently remove it from the npm registry by using the CLI. You can [unpublish][unpublish-cli] within 72 hours of the initial publish. Beyond 72 hours,so you can still unpublish your package if [it meets certain criteria](https://www.npmjs.com/policies/unpublish).
 
 <Note>
 


### PR DESCRIPTION
The timeout for republishing a package that has been unpublished is 24 hours. Updating the documentation to reflect that.


## References
Part of closing https://github.com/github/npm/issues/2234
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
