### PR TITLE
package transfers: scoped package transfers are not supported

### DIFF
--- a/content/packages-and-modules/updating-and-managing-your-published-packages/transferring-a-package-from-a-user-account-to-another-user-account.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/transferring-a-package-from-a-user-account-to-another-user-account.mdx
@@ -2,13 +2,13 @@
 title: Transferring a package from a user account to another user account
 ---
 
-As a package owner or maintainer, you can transfer ownership of a package you no longer wish to maintain to another trusted npm user on either the npm website or the command line.
+As a package owner or maintainer, you can transfer ownership of a package you no longer wish to maintain to another trusted npm user using either the npm website or the command line.
 
 For more information on how npm support handles package name disputes between users, you can refer to npm's [package name dispute policy][dispute-policy].
 
 <Note>
 
-**Note:** If your package is scoped and private, the new package owner must also have a [paid user account](https://www.npmjs.com/pricing). It is possible to transfer ownership of user-scoped packages, however we don't recommend it because it can create some ownership confusion.
+**Note:** You cannot transfer a scoped package to another user account or organization, because a package's scope _is_ the user account or organization name.  You will need to create a new package in the new scope.
 
 </Note>
 


### PR DESCRIPTION
A scope is - by definition - ownership.  We cannot transfer ownership of
scoped packages.