### PR TITLE
cli: clean up cli docs before importing them

### DIFF
--- a/.github/workflows/update-cli.yml
+++ b/.github/workflows/update-cli.yml
@@ -34,6 +34,8 @@ jobs:
       run: npm install
     - name: Fetch latest documentation
       run: node cli/cli_fetch.js
+    - name: Clean up old documentation
+      run: rm -rf content/cli
     - name: Import documentation
       run: node cli/cli_import.js
 


### PR DESCRIPTION
Remove the cli directory before doing the import; this ensures that if
some file `foo.md` is deleted that the deletion propagates.

/cc @MylesBorins 