### PR TITLE
chore: add private flag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "npm-documentation",
   "repository": "npm/documentation",
   "version": "0.1.0",
+  "private": true,
   "scripts": {
     "develop": "gatsby develop",
     "build": "gatsby build",


### PR DESCRIPTION
This is not a published package, this prevents accidentally trying to publish, and also helps us programmatically sort out which repos correlate to published packages and which don't.