### PR TITLE
policies: the dispute policy is for all naming disputes

### DIFF
--- a/content/policies/disputes.mdx
+++ b/content/policies/disputes.mdx
@@ -2,8 +2,8 @@
 title: Dispute Resolution
 ---
 
-This document describes the steps that you should take to resolve module
-name disputes with other npm publishers.  It also describes special steps
+This document describes the steps that you should take to resolve 
+naming disputes with other npm publishers.  It also describes special steps
 you should take about names you think [infringe your trademarks](#trademarks).
 
 This document is additive to the guidelines in the


### PR DESCRIPTION
Currently it specifies `module` for the naming dispute.