### PR TITLE
Fix hyperlink to package-json docs

### DIFF
--- a/content/cli/v7/using-npm/scripts.md
+++ b/content/cli/v7/using-npm/scripts.md
@@ -267,7 +267,7 @@ package.json file, then your package scripts would have the
 in your code with `process.env.npm_package_name` and
 `process.env.npm_package_version`, and so on for other fields.
 
-See [`package-json.md`](/cli/v7/using-npm/package-json) for more on package configs.
+See [`package-json.md`](/cli/v7/configuring-npm/package-json) for more on package configs.
 
 #### current lifecycle event
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Noticed this link was broken, so I updated it to point to (what I assume is) the intended page.

