### PR TITLE
Remove references to next tag

### DIFF
--- a/content/getting-started/configuring-your-local-environment/about-npm-versions.mdx
+++ b/content/getting-started/configuring-your-local-environment/about-npm-versions.mdx
@@ -6,7 +6,6 @@ slug: /about-npm-versions
 The npm command line interface (CLI) is released on a regular cadence. We recommend installing the release that supports your workflow:
 
 - [latest release](#the-latest-release-of-npm): the most recent stable version.
-- [next release](#the-next-release-of-npm): the version in current development.
 
 ## The `latest` release of npm
 
@@ -15,29 +14,3 @@ The `latest` release of npm is the most recent stable version. When you install 
 ```
 npm install npm@latest -g
 ```
-
-## The `next` release of npm
-
-<Note>
-
-The `next` release of npm may contain features that do not match the features ultimately released in the `latest` stable version of npm.
-
-More.
-
-</Note>
-
-The `next` release of npm is the version undergoing current development; it has the latest changes and newest set of features.
-
-The `next` release of npm is the most recent unreleased version of npm that is eventually released as the `latest` version. You may want to update your npm client to the `next` release to test your packages against it before `latest` is released.
-
-To update to the `next` release of npm, on the command line, run:
-
-```
-npm install npm@next -g
-```
-
-<Note>
-
-Depending on the development cycle, `npm install npm@next -g` may reinstall the `latest` release of npm.
-
-</Note>

--- a/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
+++ b/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
@@ -20,11 +20,6 @@ You can upgrade to the latest version of npm using:
 npm install -g npm@latest
 ```
 
-Or upgrade to the most recent release:
-```
-npm install -g npm@next
-```
-
 ## Upgrading on Windows
 _Microsoft wrote a small command line tool to automate the steps below. [You can go and download it here](https://github.com/felixrieseberg/npm-windows-upgrade) - or stick with the manual path outlined below._
 


### PR DESCRIPTION
We don't currently a `next` tag, so we shouldn't have instructions to install from there.

Ref: https://github.com/npm/cli/issues/3876