### PR TITLE
fix: typo from 'instalsx' to 'installs'

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/downloading-and-installing-packages-locally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/downloading-and-installing-packages-locally.mdx
@@ -51,7 +51,7 @@ ls node_modules
 
 ## Installed package version
 
-If there is a `package.json` file in the directory in which `npm install` is run, npm instalsx the latest version of the package that satisfies the [semantic versioning rule][semver] declared in `package.json`.
+If there is a `package.json` file in the directory in which `npm install` is run, npm installs the latest version of the package that satisfies the [semantic versioning rule][semver] declared in `package.json`.
 
 If there is no `package.json` file, the latest version of the package is installed.
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
One word typo fix from `instalsx` to `installs`

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
