### PR TITLE
chore: remove npm-weekly reference

### DIFF
--- a/content/about-npm/index.mdx
+++ b/content/about-npm/index.mdx
@@ -46,7 +46,7 @@ You can also use a private npm package registry like [GitHub Packages](https://g
 
 ## Learn more
 
-To learn more about npm as a product, upcoming new features, and interesting uses of npm, sign up for our newsletter at [npm-weekly](https://www.npmjs.com/npm-weekly), and be sure to follow [@npmjs](https://twitter.com/npmjs) on Twitter.
+To learn more about npm as a product, upcoming new features, and interesting uses of npm be sure to follow [@npmjs](https://twitter.com/npmjs) on Twitter.
 
 For mentoring, tutorials, and learning, visit [node school](https://nodeschool.io). Consider attending or hosting a nodeschool event (usually free!) at a site near you, or use the self-help tools you can find on the site.
 


### PR DESCRIPTION
It isn't kept up to date anymore

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
