### PR TITLE
Fix formatting in v6 docs and add more version examples

### DIFF
--- a/content/cli/v6/configuring-npm/package-json.md
+++ b/content/cli/v6/configuring-npm/package-json.md
@@ -536,19 +536,22 @@ See [semver](/cli/v6/using-npm/semver) for more details about specifying version
 For example, these are all valid:
 
 ```json
-{ "dependencies" :
-  { "foo" : "1.0.0 - 2.9999.9999"
-  , "bar" : ">=1.0.2 <2.1.2"
-  , "baz" : ">1.0.2 <=2.3.4"
-  , "boo" : "2.0.1"
-  , "qux" : "<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0"
-  , "asd" : "http://asdf.com/asdf.tar.gz"
-  , "til" : "~1.2"
-  , "elf" : "~1.2.3"
-  , "two" : "2.x"
-  , "thr" : "3.3.x"
-  , "lat" : "latest"
-  , "dyl" : "file:../dyl"
+{
+  "dependencies": {
+    "foo": "1.0.0 - 2.9999.9999", 
+    "bar": ">=1.0.2 <2.1.2", 
+    "baz": ">1.0.2 <=2.3.4",
+    "boo": "2.0.1",
+    "qux": "<1.0.0 || >=2.3.1 <2.4.5 || >=2.5.2 <3.0.0",
+    "asd": "http://asdf.com/asdf.tar.gz",
+    "til": "~1.2",
+    "elf": "~1.2.3",
+    "two": "2.x",
+    "thr": "3.3.x",
+    "fou": "*",
+    "fiv": "",
+    "lat": "latest",
+    "dyl": "file:../dyl"
   }
 }
 ```

--- a/content/cli/v7/configuring-npm/package-json.md
+++ b/content/cli/v7/configuring-npm/package-json.md
@@ -606,6 +606,8 @@ For example, these are all valid:
     "elf": "~1.2.3",
     "two": "2.x",
     "thr": "3.3.x",
+    "fou": "*",
+    "fiv": "",
     "lat": "latest",
     "dyl": "file:../dyl"
   }

--- a/content/cli/v8/configuring-npm/package-json.md
+++ b/content/cli/v8/configuring-npm/package-json.md
@@ -613,6 +613,8 @@ For example, these are all valid:
     "elf": "~1.2.3",
     "two": "2.x",
     "thr": "3.3.x",
+    "fou": "*",
+    "fiv": "",
     "lat": "latest",
     "dyl": "file:../dyl"
   }


### PR DESCRIPTION
This PR fixes JSON formatting in the example in [this section of this page](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#dependencies) and also adds more version examples to the same JSON block.
