### PR TITLE
Adding a devDependencies

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/specifying-dependencies-and-devdependencies-in-a-package-json-file.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/specifying-dependencies-and-devdependencies-in-a-package-json-file.mdx
@@ -26,6 +26,10 @@ To add an entry to the `"devDependencies"` attribute of a `package.json` file, o
 
 ```
 npm install <package-name> --save-dev
+
+OR
+
+npm install -D <package-name> 
 ```
 
 ### Manually editing the `package.json` file


### PR DESCRIPTION
An easier way of adding a development dependency. I found the --save-dev to be harder to remember to implement when I first started out programming. Hope this change helps others!

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
