### PR TITLE
fix: typos

### DIFF
--- a/content/organizations/managing-teams/managing-team-access-to-organization-packages.mdx
+++ b/content/organizations/managing-teams/managing-team-access-to-organization-packages.mdx
@@ -46,7 +46,7 @@ As an organization owner or team admin, you can add or remove package access to 
 
 ### Adding package access to a team using the CLI
 
-As an organization owner or team admin, you can use the the CLI `access` command to add package access to a team on
+As an organization owner or team admin, you can use the CLI `access` command to add package access to a team on
 the command line:
 
 ```
@@ -85,7 +85,7 @@ For more information, see "[npm-access][access-cli]".
 
 ### Removing package access from a team using the CLI
 
-As an organization owner or team admin, you can also use the the CLI `access` command to revoke package access from a team on
+As an organization owner or team admin, you can also use the CLI `access` command to revoke package access from a team on
 the command line:
 
 ```

--- a/src/shared.js
+++ b/src/shared.js
@@ -51,7 +51,7 @@ const shared = {
     },
     'billing-download-checked': {
         'text': (<>To download multiple receipts, first select the receipts that you wish to download by selecting the box next to the date.  To select all receipts, select the checkbox next to the "Date" header.  Then click <strong>Download Checked</strong>.</>),
-        'image': (<Screenshot src="/shared/billing-download-checked.png" alt="Screenshot of the the download checked option" />),
+        'image': (<Screenshot src="/shared/billing-download-checked.png" alt="Screenshot of the download checked option" />),
     },
     'billing-email': {
         'text': (<>To email a single receipt, find the row of the receipt you want to download, then, on the right side of the row, click the email icon.</>),


### PR DESCRIPTION
While reading the documentation I found adjacent"the" words in sentences. This PR addresses all sentences with two adjacent "the" words.