### PR TITLE
Clarify immediacy of making a package private

### DIFF
--- a/content/packages-and-modules/updating-and-managing-your-published-packages/changing-package-visibility.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/changing-package-visibility.mdx
@@ -22,7 +22,7 @@ For more information about package visibility, see "[Package scope, access level
 
 </Note>
 
-If you want to restrict access and visibility for a public package you own, you can make the package private. When you make a package private, it will be removed from the website within a few minutes of the change.
+If you want to restrict access and visibility for a public package you own, you can make the package private. When you make a package private, its access will be updated immediately and it will be removed from the website within a few minutes of the change.
 
 ### Using the website
 


### PR DESCRIPTION
Self-explanatory but others found this unclear, assuming that either:

1. Making a package private didn't affect CLI usage, only its website listing, or
2. Making a package private didn't take effect immediately