### PR TITLE
Fix password manager typo

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/using-private-packages-in-a-ci-cd-workflow.mdx
+++ b/content/integrations/integrating-npm-with-external-services/using-private-packages-in-a-ci-cd-workflow.mdx
@@ -85,6 +85,6 @@ Use a project-specific `.npmrc` file with a variable for your token to securely 
 
 Your token may have permission to read private packages, publish new packages on your behalf, or change user or package settings. Protect your token.
 
-Do not add your token to version control or store it insecurely. Store it in a package manager, your cloud provider's secure storage, or your CI/CD provider's secure storage.
+Do not add your token to version control or store it insecurely. Store it in a password manager, your cloud provider's secure storage, or your CI/CD provider's secure storage.
 
 [create-token]: creating-and-viewing-access-tokens


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
I think that this paragraph meant to reference storing secrets in a "password manager," not a "package manager." The latter doesn't really make sense.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
