### PR TITLE
doc: password reset no longer revokes tokens

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/revoking-access-tokens.mdx
+++ b/content/integrations/integrating-npm-with-external-services/revoking-access-tokens.mdx
@@ -5,12 +5,6 @@ redirect_from: [ /revoking-authentication-tokens ]
 
 To keep your account and packages secure, we strongly recommend revoking (deleting) tokens you no longer need or that have been compromised. You can revoke any token you have created.
 
-<Note>
-
-**Note:** While access tokens are not derived from your password, changing your password will invalidate all of your tokens. You can also invalidate a single token by logging out on a machine that is logged in with that token. We recommend revoking rather than invalidating tokens.
-
-</Note>
-
 1. To see a list of your tokens, on the command line, run:
 
    ```


### PR DESCRIPTION
This was the only place it was documented. We've updated this behavior
as we no longer have the same risk to tokens on password reset with
login verification
