### PR TITLE
doc: remove reference to outdated repository

### DIFF
--- a/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
+++ b/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
@@ -21,9 +21,6 @@ npm install -g npm@latest
 ```
 
 ## Upgrading on Windows
-_Microsoft wrote a small command line tool to automate the steps below. [You can go and download it here](https://github.com/felixrieseberg/npm-windows-upgrade) - or stick with the manual path outlined below._
-
-___
 
 By default, npm is installed alongside node in
 


### PR DESCRIPTION
Our documentation on upgrading npm on windows points to a deprecated
repo. Removing that link.

Fixes: https://github.com/npm/documentation/issues/112
