### PR TITLE
escaping italic formatting

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-scoped-public-packages.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-scoped-public-packages.mdx
@@ -88,7 +88,7 @@ By default, scoped packages are published with private visibility. To publish a 
     npm publish --access public
     ```
 
-3. To see your public package page, visit https://npmjs.com/package/*package-name*, replacing *package-name* with the name of your package. Public packages will say `public` below the package name on the npm website.
+3. To see your public package page, visit https://npmjs.com/package/\*package-name\*, replacing \*package-name\* with the name of your package. Public packages will say `public` below the package name on the npm website.
 
    <>{shared['organization-package-public'].image}</>
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
I made it, so the italic characters get escaped. Otherwise, "replacing" would be written in italic.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/69903408/172444359-a40524e4-c316-4413-b474-6e095a1b99fc.png">
<!-- 
## References
 Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
