### PR TITLE
doc: clarify required-ness of "name" and "version" in package.json files

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
@@ -25,7 +25,7 @@ to share with other developers
 
 ### Required `name` and `version` fields
 
-A `package.json` file must contain `"name"` and `"version"` fields.
+The `package.json` file of a published package must contain `"name"` and `"version"` fields.
 
 The `"name"` field contains your package's name, and must be lowercase and one word, and may contain hyphens and underscores.
 


### PR DESCRIPTION
The current content of the [Creating a package.json file](https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields) page indicates that the `"name"` and `"version"` fields are always required
> A `package.json` file must contain `"name"` and `"version"` fields.

whereas the actual [package.json docs page](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#name) clarifies this with:
> If you don't plan to publish your package, the name and version fields are optional.

This minor difference is causing some friction with e.g. Webpack making an assumption based on the former page, resulting in webpack/webpack#13457.

It would be good to get this specified; this PR attempts to do so with (hopefully!) sufficiently simple language.