### PR TITLE
tools: do pages deployment via actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,29 @@
 name: Publish
 
+
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  build:
+  build-and-upload:
     runs-on: ubuntu-latest
     steps:
     # Check out the content (source branch)
     - name: Check out source
       uses: actions/checkout@v3
-
-    # Check out the `dist` branch into the `public` directory.
-    - name: Check out documentation branch
-      uses: actions/checkout@v3
-      with:
-        ref: 'dist'
-        path: 'public'
-
+    - name: Setup Pages
+      uses: actions/configure-pages@v1
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
@@ -35,27 +37,18 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # Check for changes; this avoids publishing a new change to the
-    # dist branch when we made a change to (for example) a unit test.
-    # If there were changes made in the publish step above, then this
-    # will set the variable `has_changes` to `1` for subsequent steps.
-    - name: Check for changes
-      id: status
-      run: |
-        if [ -n "$(git status --porcelain)" ]; then
-          echo "::set-output name=has_changes::1"
-        fi
-      working-directory: public
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: './public'
 
-    # Commit the changes to the dist branch and push the changes up to
-    # GitHub.  (Replace the name and email address with your own.)
-    # This step only runs if the previous step set `has_changes` to `1`.
-    - name: Publish documentation
-      run: |
-        git add --verbose .
-        git config user.name 'npm CLI robot'
-        git config user.email 'npm-cli+bot@github.com'
-        git commit -m 'Update from CI'
-        git push origin dist
-      if: steps.status.outputs.has_changes == '1'
-      working-directory: public
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-and-upload
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
There is now support for deploying pages by actions bypassing the need to
upload to a branch, this significantly simplifies the overall process
and removed the need for a "dist" branch.

I'm about 99% confident this will work out of the box, I've tested on
two personal websites already.
