### PR TITLE
Update config option formatting for the init command.

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
@@ -155,9 +155,9 @@ Wrote to /home/monatheoctocat/my_package/package.json:
 You can set default config options for the init command. For example, to set the default author email, author name, and license, on the command line, run the following commands:
 
 ```
-> npm set init.author.email "example-user@example.com"
-> npm set init.author.name "example_user"
-> npm set init.license "MIT"
+> npm set init-author-email "example-user@example.com"
+> npm set init-author-name "example_user"
+> npm set init-license "MIT"
 ```
 
 [semver]: about-semantic-versioning


### PR DESCRIPTION
The previous commands seem to result in errors like this:

```
npm WARN config init.author.name Use `--init-author-name` instead.
```

Even more confusingly, if you run the old commands then you end up with the dot-based syntax in your config, which surfaces as an error even if you use the *correct* syntax for new entries going forward:

```
> npm set init.author.email "example-user@example.com"
npm WARN config init.author.email Use `--init-author-email` instead.
> npm set init-author-email "example-user@example.com" # note: correct syntax!
npm WARN config init.author.email Use `--init-author-email` instead.
```

It might be helpful to explain that in these docs, although I haven't tried to tackle it in this PR.