### PR TITLE
tools: pages read permission to build-and-upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
   build-and-upload:
     permissions:
       contents: read
+      pages: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Adding this permission is necessary to support private repos
