### PR TITLE
Added a brief expansion of the term npm

### DIFF
--- a/content/about-npm/index.mdx
+++ b/content/about-npm/index.mdx
@@ -3,7 +3,7 @@ title: About npm
 redirect_from: [ /getting-started/what-is-npm ]
 ---
 
-npm is the world's largest software registry. Open source developers from every continent use npm to share and borrow packages, and many organizations use npm to manage private development as well.
+npm (Node Package Manager) is the world's largest software registry. Open source developers from every continent use npm to share and borrow packages, and many organizations use npm to manage private development as well.
 
 npm consists of three distinct components:
 


### PR DESCRIPTION
I wanted to reference npm where my readers would understand what npm stands for (represents). I found this about page and discovered it doesn't say what npm stands for (unlike https://www.w3schools.com/whatis/whatis_npm.asp#:~:text=The%20name%20npm%20(Node%20Package,json.)

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
