### PR TITLE
fix: remove update cli cronjob

### DIFF
--- a/.github/workflows/update-cli.yml
+++ b/.github/workflows/update-cli.yml
@@ -2,8 +2,6 @@ name: Update CLI
 
 on:
   workflow_dispatch:
-  schedule:
-  - cron: "14 2 * * *"
 
 jobs:
   update-cli:


### PR DESCRIPTION
The release process for the CLI now handles manually triggering a
`workflow_dispatch` on the update-cli workflow.

This will also prevent any prerelease versions getting published to the
the documentation site since it build directly from `latest` where
prerelease development will be happening.

A future PR will change that behavior so docs are built from registry
tags.
