### PR TITLE
Update docker-and-private-modules.mdx

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
+++ b/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
@@ -47,7 +47,7 @@ WORKDIR ${APP_HOME}
 
 COPY package*.json ${APP_HOME}/
 
-RUN --mount=type=secret,id=npmrc,target=.npmrc npm install
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc npm install
 
 COPY . ${APP_HOME}/
 

--- a/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
+++ b/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
@@ -4,87 +4,71 @@ redirect_from:
   - /private-modules/docker-and-private-modules
 ---
 
-To install private npm packages in a Docker container, you will need to use Docker's build-time variables.
+To install private npm packages in a Docker container, you will need to use [Docker build secrets](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information).
 
 ## Background: runtime variables
 
-You cannot install private npm packages in a Docker container using only runtime variables.  Consider the following Dockerfile:
+You cannot install private npm packages in a Docker container using only runtime variables. Consider the following Dockerfile:
 
 ```
 FROM node
 
-COPY package.json package.json  
+COPY package.json package.json
 RUN npm install
 
 # Add your source files
-COPY . .  
-CMD npm start  
+COPY . .
+CMD npm start
 ```
 
 Which will use the official [Node.js](https://hub.docker.com/_/node) image, copy the `package.json` into our container, installs dependencies, copies the source files and runs the start command as specified in the `package.json`.
 
 In order to install private packages, you may think that we could just add a line before we run `npm install`, using the [ENV parameter](https://docs.docker.com/engine/reference/builder/#env):
 
-```
+```docker
 ENV NPM_TOKEN=00000000-0000-0000-0000-000000000000
 ```
 
 However, this doesn't work as you would expect, because you want the npm install to occur when you run `docker build`, and in this instance, `ENV` variables aren't used, they are set for runtime only.
 
-Instead of run-time variables, you must use a different way of passing environment variables to Docker, available since Docker 1.9: the [ARG parameter](https://docs.docker.com/engine/reference/builder/#arg).
-
-## Create and check in a project-specific .npmrc file
-
-A complete example that will allow you to use `--build-arg` to pass in your NPM_TOKEN requires adding a `.npmrc` file to the project.
-
-Use a project-specific `.npmrc` file with a variable for your token to securely authenticate your Docker image with npm.
-
-1. In the root directory of your project, create a custom <a href="https://docs.npmjs.com/cli-documentation/files/npmrc">`.npmrc`</a> file with the following contents:
-
-   ```
-   //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-   ```
-
-   **Note:** that you are specifying a literal value of `${NPM_TOKEN}`.  The npm cli will replace this value with the contents of the `NPM_TOKEN` environment variable.  Do **not** put a token in this file.
-
-2. Check in the `.npmrc` file.
+Instead of run-time variables, you must use Docker build secrets.
 
 ## Update the Dockerfile
 
-The Dockerfile that takes advantage of this has a few more lines in it than the earlier example that allows us to use the `.npmrc` file and the `ARG` parameter:
+The Dockerfile that takes advantage of this has a few more lines in it than the earlier example that allows us to use your global `.npmrc` and the access token created when running `npm login` command (if you haven't run it already - do so before moving on).
 
-```
-FROM node
+```dockerfile
+# https://docs.npmjs.com/docker-and-private-modules
+FROM node:16
 
-ARG NPM_TOKEN  
-COPY .npmrc .npmrc  
-COPY package.json package.json  
-RUN npm install  
-RUN rm -f .npmrc
+ENV APP_HOME="/app"
 
-# Add your source files
-COPY . .  
+WORKDIR ${APP_HOME}
+
+COPY package*.json ${APP_HOME}/
+
+RUN --mount=type=secret,id=npmrc,target=.npmrc npm install
+
+COPY . ${APP_HOME}/
+
 CMD npm start
+
 ```
 
-This adds the expected `ARG NPM_TOKEN`, but also copies the `.npmrc` file, and removes it when `npm install` completes.
+This will configure your Dockerfile to receive `.npmrc` file via build secrets, that will leave no trace after npm dependency installation is done.
 
 ## Build the Docker image
 
 To build the image using the above Dockerfile and the npm authentication token, you can run the following command. Note the `.` at the end to give `docker build` the current directory as an argument.
 
-```
-docker build --build-arg NPM_TOKEN=${NPM_TOKEN} .
+```shell
+docker build . -t secure-app-secrets:1.0 --secret id=npmrc,src=$HOME/.npmrc
 ```
 
-This will build the Docker image with the current `NPM_TOKEN` environment variable, so you can run `npm install` inside your container as the current logged-in user.
+This will build the Docker image with the access token coming from your global `.npmrc` file received via build secrets, so you can run `npm install` inside your container as the current logged-in user.
 
 <Note>
 
-**Note:** Even if you delete the `.npmrc` file, it will be kept in the commit history. To clean your secrets entirely, make sure to squash them.
-
-**Note:** You may commit the `.npmrc` file under a different name, e.g. `.npmrc.docker` to prevent local build from using it.
-
-**Note:** You may need to specify a working directory different from the default `/`  otherwise some frameworks like Angular will fail.
+**Note:** You may need to specify a working directory different from the default `/` otherwise some frameworks like Angular will fail.
 
 </Note>


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

# Passing build to the original PR #103 

For all the discussion that went into creating the new version of `docker-and-private-modules.mdx` please visit the original PR #103.

Description from the original PR #103:

> I think there's a better approach and this section needs a big rewrite. The approach has been explained really well [here][Securely using NPM credentials with Docker].
> 
> Currently, npm docs encourages to use [`ARG` parameter  and `--build-arg` option](https://docs.docker.com/engine/reference/builder/#arg). When we follow the [link](https://docs.docker.com/engine/reference/builder/#arg) in the documentation we're going to end up reading a Warning and will be taken to [a better and newer solution][New Docker Build secret information] which does not use `ARG` but the global `.npmrc` file and which I've shown below as well.
> 
> I think this should be a more appropriate way of doing it:
> 
> 1. Remember to login with `npm login` if you haven't already.
> 
> 2. `Dockerfile`:
> ```Dockerfile
> # https://docs.npmjs.com/docker-and-private-modules
> FROM node:14
> 
> ENV APP_HOME="/app/"
> 
> WORKDIR ${APP_HOME}
> 
> COPY package*.json ${APP_HOME}/
> 
> RUN --mount=type=secret,id=npm,target=/root/.npmrc npm install
> 
> COPY . ${APP_HOME}/
> CMD npm start
> ```
> 
> 3. Build docker image with the command (on mac in this case)
> ```shell
> docker build . -t secure-app-secrets:1.0 --secret id=npm,src=$HOME/.npmrc
> ```
> 
> If this solution finds some traction and acceptance I'm going to change this PR to include this solution but I feel like this would require a bigger re-write of this entire page if we're going to agree that this is the solution that should be promoted. 
> 
> My reasons for promoting it would be:
> - Does not require setting of local `NPM_TOKEN` environment variable as the token is being taken from the global `.npmrc` which uses the token created during `npm login` phase and does not store it either
> - No need to create local `.npmrc` and risk that someone will put their access token there and commit to source control
> - No risk that someone will pass their access token to `docker build` command and make it visible in the docker image
> - No need to worry about token getting into your terminal history
> - [Seems to be using the latest docker features][New Docker Build secret information]
> 
> Again, happy to be shown a better way or maybe there is nothing wrong with the current solution. Either way, I'm opened to discussion and with the recent leak of [npm access token](https://thehackernews.com/2022/04/github-says-hackers-breach-dozens-of.html) I feel like it's an important one to have. 
> 
> ## References
> [New Docker Build secret information]: https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information
> [Securely using NPM credentials with Docker]: https://medium.com/learnwithrahul/securely-using-npm-credentials-with-docker-f38b43bdb7c1
> <!-- Examples:
>   Related to #0
>   Depends on #0
>   Blocked by #0
>   Fixes #0
>   Closes #0
> -->
> - [Using auth tokens in .npmrc](https://stackoverflow.com/questions/53099434/using-auth-tokens-in-npmrc)
> - [How to set env var for .npmrc use](https://stackoverflow.com/questions/48728714/how-to-set-env-var-for-npmrc-use)
> - [Docker build secrets and private npm packages](https://www.alexandraulsh.com/2019/02/24/docker-build-secrets-and-npmrc/)
> - [Securely using .npmrc files in Docker images](https://www.alexandraulsh.com/2018/06/25/docker-npmrc-security/)
> - [Build secrets and SSH forwarding in Docker 18.09](https://medium.com/@tonistiigi/build-secrets-and-ssh-forwarding-in-docker-18-09-ae8161d066)
> 