### PR TITLE
docs: Add note to docker-and-private-modules about security

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
+++ b/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
@@ -81,6 +81,8 @@ This will build the Docker image with the current `NPM_TOKEN` environment variab
 
 <Note>
 
+**Note:** The value of the --build-arg will be available to anyone with access to your built image in plain text via `docker history`. Care should be taken to ensure you are not leaking this value by distributing your built image. Take a look at the `--secret` option available in docker buildkit for a more secure alternative. 
+
 **Note:** Even if you delete the `.npmrc` file, it will be kept in the commit history. To clean your secrets entirely, make sure to squash them.
 
 **Note:** You may commit the `.npmrc` file under a different name, e.g. `.npmrc.docker` to prevent local build from using it.


### PR DESCRIPTION
 * Adding note about security implications of using docker --build-arg

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
