### PR TITLE
Update creating-and-publishing-unscoped-public-packages.mdx

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-unscoped-public-packages.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-unscoped-public-packages.mdx
@@ -53,7 +53,7 @@ For less sensitive information, such as testing data, use a `.npmignore` or `.gi
 To reduce the chances of publishing bugs, we recommend testing your package before publishing it to the npm registry. To test your package, run `npm install` with the full path to your package directory:
 
 ```
-npm install my-package
+npm install path/to/my-package
 ```
 
 ## Publishing unscoped public packages


### PR DESCRIPTION
<!-- What / Why -->
Use path notation instead of package name, which is more intuitive in given case.
<!-- Describe the request in detail. What it does and why it's being changed. -->
`npm install package` doesn't work for testing package locally.