### PR TITLE
Added arrow key navigation

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,46 @@
+const React = require("react")
+
+exports.wrapPageElement = ({ element, props }) => {
+  // props provide same data to Layout as Page element will get
+  // including location, data, etc - you don't need to pass it
+  return <div {...props} onKeyDown={onKeyDown}>{element}</div>
+}
+
+function onKeyDown(event) {
+  if(!document.activeElement) {
+    return
+  }
+  const { activeElement } = document
+  const allLinks = getFocusableElements()
+  if(event.key === 'ArrowDown' || event.key === 'ArrowUp' ) {
+    const activeIndex = getIndex(allLinks, activeElement)
+    if (activeIndex === -1) {
+      return
+    }
+    let nextIndex = activeIndex
+    if (event.key === 'ArrowDown') {
+      nextIndex++
+    } else {
+      nextIndex--
+    }
+    if (nextIndex >=0 && nextIndex < allLinks.length) {
+      allLinks[nextIndex].focus()
+    }
+  }
+}
+
+function getIndex(allLinks, activeElement) {
+  for (let index=0; index < allLinks.length; index++) {
+    const link = allLinks[index]
+    if (link === activeElement) {
+      return index
+    }
+  }
+  return -1
+}
+
+function getFocusableElements() {
+  return document.querySelectorAll(
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), details:not([disabled]), summary:not(:disabled)'
+  );
+}


### PR DESCRIPTION
Wrapped page and added onKeyDown handler in gatsby-browser.js file
Demo:

[simplescreenrecorder-2022-10-03_10.54.31.webm](https://user-images.githubusercontent.com/103434939/193519673-41ff4287-e510-4402-9c41-cd796cbd7941.webm)


## References
github/accessibility-audits#2740
