### PR TITLE
fix: generate discoverable redirects for all `/cli` paths

### DIFF
--- a/cli/lib/build.js
+++ b/cli/lib/build.js
@@ -73,6 +73,7 @@ const main = async ({
     src: release.src?.split(posix.sep).join(sep) || defaultBuiltDir,
     url: `/${DOCS_PATH}/${release.id}`,
     urlPrefix: DOCS_PATH,
+    urlPrefixes: [DOCS_PATH, `${DOCS_PATH}-documentation`],
   }))
 
   const baseNav = await fs.readFile(navPath, 'utf-8')

--- a/cli/lib/redirects.js
+++ b/cli/lib/redirects.js
@@ -1,72 +1,87 @@
-// TODO: many of these redirects can be simplified now that
-// they are looked up using minimatch.
-module.exports = Object.entries({
-  // indexes
-  index: ['/cli', '/cli-documentation'],
-  '*/index': ({ section }) => [`/${section}`, `/cli/${section}`],
+const { posix: { join } } = require('path')
+
+// An object to generate redirects for a given path.
+// The key is a glob path that is matched by minimatch,
+// and the value is a function that is passed a parsed
+// path with { section, page, release }.
+//
+// Return an absolute path to bypass the normal /cli/
+// folder prefix to the redirect path. These will only
+// be applied for the default release or if an object
+// with `default: true` is also returned.
+//
+// The order of the keys is important because the result of
+// one redirect can generate other redirects if they match
+// one of the remaining globs. So keys should be ordered
+// from the least specific -> most specific. Note that this
+// order is reversed when actually parsing the object and
+// running the code so it works properly.
+//
+// For example: path -> configuring-npm/package-lock-json
+// This will first match: configuring-npm/*
+// which will generate the redirects files/package-lock-json
+// Later this will match: **/*-json*
+// So both redirects from: configuring-npm/package-lock.json
+// and files/package-lock.json will also be created.
+//
+// Note that all redirects are deduped later so it is safe
+// if a path creates multiple idential redirects. Gatsby
+// will also warn (but not create them) if multiple pages
+// redirect to the same or already exsiting paths.
+
+module.exports = {
+  index: () => ['.'],
+  '*/!(index)': ({ section, page }) => [
+    join(section, page),
+    join('/', section, page),
+  ],
+  '*/index': ({ section, page }) => [
+    join(section),
+    join('/', section),
+    join(section, page),
+    join('/', section, page),
+  ],
+
+  // any page with `-json` -> `.json`
+  '**/*-json*': ({ section, page }) => [
+    join(section, page.replace(/-json/g, '.json')),
+  ],
+
   // commands
-  'commands/!(index|npx)': ({ section, page }) => {
-    const command = page.replace(/^npm-/, '')
-    return [
-      `/cli/${command}`,
-      `/cli/${command}.html`,
-      `/cli/${section}/${command}`,
-      `/cli-${section}/${page}`,
-      `/cli-${section}/${command}`,
-      `/cli-${section}/${command}.html`,
-    ]
-  },
-  'commands/index': [
+  'commands/!(index)': ({ page }) => [
+    page,
+  ],
+  'commands/index': () => [
     '/cli-documentation/cli',
-    '/cli-documentation/cli-commands',
   ],
-  'commands/npm-access': ['/cli-documentation/access'],
-  'commands/npm-install': ['/cli-documentation/install'],
+  'commands/*': ({ page }) => [
+    join('cli-commands', page),
+    join('/', 'cli-commands', page),
+  ],
+  'commands/npm-*': ({ section, page }) => [
+    join(section, page.replace(/^npm-/, '')),
+  ],
+
   // configuring npm
-  'configuring-npm/!(index)': ({ section, page }) => [
-    `/${section}/${page}`,
-    `/${section}/${page}.html`,
+  'configuring-npm/*': ({ page }) => [
+    join('files', page),
+    join('/', 'files', page),
   ],
-  'configuring-npm/index': [
-    '/cli-documentation/configuring-npm',
-    '/cli-documentation/files',
+  'configuring-npm/package-locks': ({ section, page, release }) => [
+    // A special case for a path that was deleted in v7, but we still
+    // want the old v6 default url to resolve.
+    { path: join('/', section, page), default: release.id === 'v6' },
   ],
-  'configuring-npm/folders': ['/files/folders', '/files/folders.html'],
-  'configuring-npm/npmrc': [
-    '/cli-documentation/files/npmrc',
-    '/files/npmrc',
-    '/files/npmrc.html',
-  ],
-  'configuring-npm/package-json': [
-    '/configuring-npm/package.json',
-    '/creating-a-packge-json-file',
-    '/files/package.json',
-    '/files/package.json.html',
-  ],
-  'configuring-npm/package-lock-json': [
-    '/files/package-lock.json',
-    '/files/package-lock.json.html',
-  ],
-  'configuring-npm/package-locks': [
-    '/files/package-locks',
-    '/files/package-locks.html',
-  ],
-  'configuring-npm/shrinkwrap-json': [
-    '/files/shrinkwrap.json',
-    '/files/shrinkwrap.json.html',
-  ],
+
   // using npm
-  'using-npm/!(index)': ({ section, page }) => [
-    `/${section}/${page}`,
-    `/${section}/${page}.html`,
-    `/misc/${page}`,
-    `/misc/${page}.html`,
+  'using-npm/*': ({ page }) => [
+    join('misc', page),
+    join('/', 'misc', page),
   ],
-  'using-npm/index': [
-    '/cli-documentation/misc',
-    '/cli-documentation/using-npm',
-    '/misc/index.html',
+  'using-npm/removal': ({ section }) => [
+    join(section, 'removing-npm'),
   ],
-  'using-npm/removal': ['/misc/removing-npm', '/misc/removing-npm.html'],
-  'using-npm/scope': ['/using-npm/npm-scope'],
-})
+  'using-npm/scope': ({ section }) => [
+    join(section, 'npm-scope'),
+  ],
+}

--- a/cli/lib/transform.js
+++ b/cli/lib/transform.js
@@ -2,31 +2,63 @@ const parseFm = require('front-matter')
 const Minipass = require('minipass')
 const yaml = require('yaml')
 const minimatch = require('minimatch')
-const { sep, extname, join, posix } = require('path')
+const { sep, join, posix, isAbsolute } = require('path')
 const gh = require('./gh')
-const redirectsMap = require('./redirects')
+const rawRedirects = require('./redirects')
 
-const getRedirects = ({ path: _path, release }) => {
-  if (!release.default) {
-    return []
+const getPathParts = (path) => {
+  const abs = isAbsolute(path)
+  const paths = path.replace(/\.mdx?$/, '').split(sep)
+
+  const pathId = posix.join(abs ? '/' : '', ...paths)
+  const page = posix.basename(pathId)
+  const section = posix.dirname(pathId)
+
+  return {
+    path: pathId,
+    page,
+    section: section === '.' ? '' : section,
+  }
+}
+
+const getRedirects = ({ path, release }) => {
+  const redirects = [getPathParts(path)]
+  const [pagePath] = redirects
+  const canonical = posix.join(
+    release.url,
+    pagePath.section,
+    pagePath.page === 'index' ? '' : pagePath.page
+  )
+
+  for (const [k, v] of Object.entries(rawRedirects).reverse()) {
+    const pageRedirects = redirects.flatMap(redirect => {
+      if (minimatch(redirect.path, k)) {
+        return v({ ...getPathParts(redirect.path), release }).map(p => ({
+          ...redirect,
+          ...typeof p === 'object' ? p : { path: p },
+        }))
+      }
+    })
+    redirects.push(...pageRedirects.filter(Boolean))
   }
 
-  const paths = _path.replace(new RegExp(`\\${extname(_path)}$`), '').split(sep)
-  const path = posix.join(...paths)
-  const section = paths.length === 1 ? '' : posix.dirname(path)
-  const page = paths.length === 1 ? 'index' : posix.basename(path)
-
-  const redirects = redirectsMap
-    .filter(([k]) => minimatch(path, k))
-    .flatMap(([, pageRedirects]) => {
-      return [].concat(
-        typeof pageRedirects === 'function'
-          ? pageRedirects({ section, page })
-          : pageRedirects
-      )
+  const prefixRedirects = redirects
+    .flatMap(redirect => {
+      const useDefault = redirect.default || release.default
+      if (isAbsolute(redirect.path)) {
+        return useDefault ? redirect.path : null
+      } else {
+        return release.urlPrefixes.flatMap(p => [
+          posix.join('/', p, release.id, redirect.path),
+          useDefault ? posix.join('/', p, redirect.path) : null,
+        ])
+      }
     })
+    .filter(Boolean)
+    .filter(r => r !== canonical)
 
-  return [...new Set(redirects)].sort((a, b) => a.localeCompare(b, 'en'))
+  return [...new Set(prefixRedirects)]
+    .sort((a, b) => a.localeCompare(b, 'en'))
 }
 
 const transform = (data, { release, path, frontmatter }) => {

--- a/cli/test/transform.js
+++ b/cli/test/transform.js
@@ -1,0 +1,90 @@
+const t = require('tap')
+const fm = require('front-matter')
+const Transform = require('../lib/transform')
+
+const transform = ({ id, path }) => {
+  const transformed = Transform.sync('---\n---\n', {
+    release: {
+      id: id,
+      default: id === 'v8',
+      src: 'docs/content',
+      url: `/cli/${id}/${path}`,
+      urlPrefixes: ['/cli'],
+    },
+    path,
+  })
+  return fm(transformed).attributes
+}
+
+t.test('v6 default page', async t => {
+  const v6 = transform({ id: 'v6', path: 'configuring-npm/package-locks' })
+  const v7 = transform({ id: 'v7', path: 'configuring-npm/package-locks' })
+
+  t.strictSame(v6.redirect_from, [
+    '/cli/v6/configuring-npm/package-locks',
+    '/cli/v6/files/package-locks',
+    '/configuring-npm/package-locks',
+  ])
+  t.strictSame(v7.redirect_from, [
+    '/cli/v7/configuring-npm/package-locks',
+    '/cli/v7/files/package-locks',
+  ])
+})
+
+t.test('command', async t => {
+  const v7 = transform({ id: 'v7', path: 'commands/npm-bin' })
+  const v8 = transform({ id: 'v8', path: 'commands/npm-bin' })
+
+  t.strictSame(v7.redirect_from, [
+    '/cli/v7/bin',
+    '/cli/v7/cli-commands/bin',
+    '/cli/v7/cli-commands/npm-bin',
+    '/cli/v7/commands/bin',
+    '/cli/v7/commands/npm-bin',
+    '/cli/v7/npm-bin',
+  ])
+  t.strictSame(v8.redirect_from, [
+    '/cli-commands/bin',
+    '/cli-commands/npm-bin',
+    '/cli/bin',
+    '/cli/cli-commands/bin',
+    '/cli/cli-commands/npm-bin',
+    '/cli/commands/bin',
+    '/cli/commands/npm-bin',
+    '/cli/npm-bin',
+    '/cli/v8/bin',
+    '/cli/v8/cli-commands/bin',
+    '/cli/v8/cli-commands/npm-bin',
+    '/cli/v8/commands/bin',
+    '/cli/v8/commands/npm-bin',
+    '/cli/v8/npm-bin',
+    '/commands/bin',
+    '/commands/npm-bin',
+  ])
+})
+
+t.test('package-json files', async t => {
+  const v7 = transform({ id: 'v7', path: 'configuring-npm/package-json' })
+  const v8 = transform({ id: 'v8', path: 'configuring-npm/package-json' })
+
+  t.strictSame(v7.redirect_from, [
+    '/cli/v7/configuring-npm/package-json',
+    '/cli/v7/configuring-npm/package.json',
+    '/cli/v7/files/package-json',
+    '/cli/v7/files/package.json',
+  ])
+  t.strictSame(v8.redirect_from, [
+    '/cli/configuring-npm/package-json',
+    '/cli/configuring-npm/package.json',
+    '/cli/files/package-json',
+    '/cli/files/package.json',
+    '/cli/v8/configuring-npm/package-json',
+    '/cli/v8/configuring-npm/package.json',
+    '/cli/v8/files/package-json',
+    '/cli/v8/files/package.json',
+    '/configuring-npm/package-json',
+    '/configuring-npm/package.json',
+    '/files/package-json',
+    '/files/package.json',
+  ])
+})

--- a/content/cli/v6/commands/index.mdx
+++ b/content/cli/v6/commands/index.mdx
@@ -3,6 +3,14 @@ title: CLI Commands
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v6/cli-commands
+  - /cli-documentation/v6/cli-commands/index
+  - /cli-documentation/v6/commands
+  - /cli-documentation/v6/commands/index
+  - /cli/v6/cli-commands
+  - /cli/v6/cli-commands/index
+  - /cli/v6/commands/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v6/commands/npm-access.md
+++ b/content/cli/v6/commands/npm-access.md
@@ -5,6 +5,18 @@ description: Set access level on published packages
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-access.md
+redirect_from:
+  - /cli-documentation/v6/access
+  - /cli-documentation/v6/cli-commands/access
+  - /cli-documentation/v6/cli-commands/npm-access
+  - /cli-documentation/v6/commands/access
+  - /cli-documentation/v6/commands/npm-access
+  - /cli-documentation/v6/npm-access
+  - /cli/v6/access
+  - /cli/v6/cli-commands/access
+  - /cli/v6/cli-commands/npm-access
+  - /cli/v6/commands/access
+  - /cli/v6/npm-access
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-adduser.md
+++ b/content/cli/v6/commands/npm-adduser.md
@@ -5,6 +5,18 @@ description: Add a registry user account
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-adduser.md
+redirect_from:
+  - /cli-documentation/v6/adduser
+  - /cli-documentation/v6/cli-commands/adduser
+  - /cli-documentation/v6/cli-commands/npm-adduser
+  - /cli-documentation/v6/commands/adduser
+  - /cli-documentation/v6/commands/npm-adduser
+  - /cli-documentation/v6/npm-adduser
+  - /cli/v6/adduser
+  - /cli/v6/cli-commands/adduser
+  - /cli/v6/cli-commands/npm-adduser
+  - /cli/v6/commands/adduser
+  - /cli/v6/npm-adduser
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-audit.md
+++ b/content/cli/v6/commands/npm-audit.md
@@ -5,6 +5,18 @@ description: Run a security audit
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-audit.md
+redirect_from:
+  - /cli-documentation/v6/audit
+  - /cli-documentation/v6/cli-commands/audit
+  - /cli-documentation/v6/cli-commands/npm-audit
+  - /cli-documentation/v6/commands/audit
+  - /cli-documentation/v6/commands/npm-audit
+  - /cli-documentation/v6/npm-audit
+  - /cli/v6/audit
+  - /cli/v6/cli-commands/audit
+  - /cli/v6/cli-commands/npm-audit
+  - /cli/v6/commands/audit
+  - /cli/v6/npm-audit
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-bin.md
+++ b/content/cli/v6/commands/npm-bin.md
@@ -5,6 +5,18 @@ description: Display npm bin folder
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-bin.md
+redirect_from:
+  - /cli-documentation/v6/bin
+  - /cli-documentation/v6/cli-commands/bin
+  - /cli-documentation/v6/cli-commands/npm-bin
+  - /cli-documentation/v6/commands/bin
+  - /cli-documentation/v6/commands/npm-bin
+  - /cli-documentation/v6/npm-bin
+  - /cli/v6/bin
+  - /cli/v6/cli-commands/bin
+  - /cli/v6/cli-commands/npm-bin
+  - /cli/v6/commands/bin
+  - /cli/v6/npm-bin
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-bugs.md
+++ b/content/cli/v6/commands/npm-bugs.md
@@ -5,6 +5,18 @@ description: Bugs for a package in a web browser maybe
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-bugs.md
+redirect_from:
+  - /cli-documentation/v6/bugs
+  - /cli-documentation/v6/cli-commands/bugs
+  - /cli-documentation/v6/cli-commands/npm-bugs
+  - /cli-documentation/v6/commands/bugs
+  - /cli-documentation/v6/commands/npm-bugs
+  - /cli-documentation/v6/npm-bugs
+  - /cli/v6/bugs
+  - /cli/v6/cli-commands/bugs
+  - /cli/v6/cli-commands/npm-bugs
+  - /cli/v6/commands/bugs
+  - /cli/v6/npm-bugs
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-build.md
+++ b/content/cli/v6/commands/npm-build.md
@@ -5,6 +5,18 @@ description: Build a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-build.md
+redirect_from:
+  - /cli-documentation/v6/build
+  - /cli-documentation/v6/cli-commands/build
+  - /cli-documentation/v6/cli-commands/npm-build
+  - /cli-documentation/v6/commands/build
+  - /cli-documentation/v6/commands/npm-build
+  - /cli-documentation/v6/npm-build
+  - /cli/v6/build
+  - /cli/v6/cli-commands/build
+  - /cli/v6/cli-commands/npm-build
+  - /cli/v6/commands/build
+  - /cli/v6/npm-build
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-bundle.md
+++ b/content/cli/v6/commands/npm-bundle.md
@@ -5,6 +5,18 @@ description: REMOVED
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-bundle.md
+redirect_from:
+  - /cli-documentation/v6/bundle
+  - /cli-documentation/v6/cli-commands/bundle
+  - /cli-documentation/v6/cli-commands/npm-bundle
+  - /cli-documentation/v6/commands/bundle
+  - /cli-documentation/v6/commands/npm-bundle
+  - /cli-documentation/v6/npm-bundle
+  - /cli/v6/bundle
+  - /cli/v6/cli-commands/bundle
+  - /cli/v6/cli-commands/npm-bundle
+  - /cli/v6/commands/bundle
+  - /cli/v6/npm-bundle
 ---
 
 ### Description

--- a/content/cli/v6/commands/npm-cache.md
+++ b/content/cli/v6/commands/npm-cache.md
@@ -5,6 +5,18 @@ description: Manipulates packages cache
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-cache.md
+redirect_from:
+  - /cli-documentation/v6/cache
+  - /cli-documentation/v6/cli-commands/cache
+  - /cli-documentation/v6/cli-commands/npm-cache
+  - /cli-documentation/v6/commands/cache
+  - /cli-documentation/v6/commands/npm-cache
+  - /cli-documentation/v6/npm-cache
+  - /cli/v6/cache
+  - /cli/v6/cli-commands/cache
+  - /cli/v6/cli-commands/npm-cache
+  - /cli/v6/commands/cache
+  - /cli/v6/npm-cache
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-ci.md
+++ b/content/cli/v6/commands/npm-ci.md
@@ -5,6 +5,18 @@ description: Install a project with a clean slate
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-ci.md
+redirect_from:
+  - /cli-documentation/v6/ci
+  - /cli-documentation/v6/cli-commands/ci
+  - /cli-documentation/v6/cli-commands/npm-ci
+  - /cli-documentation/v6/commands/ci
+  - /cli-documentation/v6/commands/npm-ci
+  - /cli-documentation/v6/npm-ci
+  - /cli/v6/ci
+  - /cli/v6/cli-commands/ci
+  - /cli/v6/cli-commands/npm-ci
+  - /cli/v6/commands/ci
+  - /cli/v6/npm-ci
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-completion.md
+++ b/content/cli/v6/commands/npm-completion.md
@@ -5,6 +5,18 @@ description: Tab Completion for npm
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-completion.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/completion
+  - /cli-documentation/v6/cli-commands/npm-completion
+  - /cli-documentation/v6/commands/completion
+  - /cli-documentation/v6/commands/npm-completion
+  - /cli-documentation/v6/completion
+  - /cli-documentation/v6/npm-completion
+  - /cli/v6/cli-commands/completion
+  - /cli/v6/cli-commands/npm-completion
+  - /cli/v6/commands/completion
+  - /cli/v6/completion
+  - /cli/v6/npm-completion
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-config.md
+++ b/content/cli/v6/commands/npm-config.md
@@ -5,6 +5,18 @@ description: Manage the npm configuration files
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-config.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/config
+  - /cli-documentation/v6/cli-commands/npm-config
+  - /cli-documentation/v6/commands/config
+  - /cli-documentation/v6/commands/npm-config
+  - /cli-documentation/v6/config
+  - /cli-documentation/v6/npm-config
+  - /cli/v6/cli-commands/config
+  - /cli/v6/cli-commands/npm-config
+  - /cli/v6/commands/config
+  - /cli/v6/config
+  - /cli/v6/npm-config
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-dedupe.md
+++ b/content/cli/v6/commands/npm-dedupe.md
@@ -5,6 +5,18 @@ description: Reduce duplication
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-dedupe.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/dedupe
+  - /cli-documentation/v6/cli-commands/npm-dedupe
+  - /cli-documentation/v6/commands/dedupe
+  - /cli-documentation/v6/commands/npm-dedupe
+  - /cli-documentation/v6/dedupe
+  - /cli-documentation/v6/npm-dedupe
+  - /cli/v6/cli-commands/dedupe
+  - /cli/v6/cli-commands/npm-dedupe
+  - /cli/v6/commands/dedupe
+  - /cli/v6/dedupe
+  - /cli/v6/npm-dedupe
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-deprecate.md
+++ b/content/cli/v6/commands/npm-deprecate.md
@@ -5,6 +5,18 @@ description: Deprecate a version of a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-deprecate.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/deprecate
+  - /cli-documentation/v6/cli-commands/npm-deprecate
+  - /cli-documentation/v6/commands/deprecate
+  - /cli-documentation/v6/commands/npm-deprecate
+  - /cli-documentation/v6/deprecate
+  - /cli-documentation/v6/npm-deprecate
+  - /cli/v6/cli-commands/deprecate
+  - /cli/v6/cli-commands/npm-deprecate
+  - /cli/v6/commands/deprecate
+  - /cli/v6/deprecate
+  - /cli/v6/npm-deprecate
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-dist-tag.md
+++ b/content/cli/v6/commands/npm-dist-tag.md
@@ -5,6 +5,18 @@ description: Modify package distribution tags
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-dist-tag.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/dist-tag
+  - /cli-documentation/v6/cli-commands/npm-dist-tag
+  - /cli-documentation/v6/commands/dist-tag
+  - /cli-documentation/v6/commands/npm-dist-tag
+  - /cli-documentation/v6/dist-tag
+  - /cli-documentation/v6/npm-dist-tag
+  - /cli/v6/cli-commands/dist-tag
+  - /cli/v6/cli-commands/npm-dist-tag
+  - /cli/v6/commands/dist-tag
+  - /cli/v6/dist-tag
+  - /cli/v6/npm-dist-tag
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-docs.md
+++ b/content/cli/v6/commands/npm-docs.md
@@ -5,6 +5,18 @@ description: Docs for a package in a web browser maybe
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-docs.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/docs
+  - /cli-documentation/v6/cli-commands/npm-docs
+  - /cli-documentation/v6/commands/docs
+  - /cli-documentation/v6/commands/npm-docs
+  - /cli-documentation/v6/docs
+  - /cli-documentation/v6/npm-docs
+  - /cli/v6/cli-commands/docs
+  - /cli/v6/cli-commands/npm-docs
+  - /cli/v6/commands/docs
+  - /cli/v6/docs
+  - /cli/v6/npm-docs
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-doctor.md
+++ b/content/cli/v6/commands/npm-doctor.md
@@ -5,6 +5,18 @@ description: Check your environments
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-doctor.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/doctor
+  - /cli-documentation/v6/cli-commands/npm-doctor
+  - /cli-documentation/v6/commands/doctor
+  - /cli-documentation/v6/commands/npm-doctor
+  - /cli-documentation/v6/doctor
+  - /cli-documentation/v6/npm-doctor
+  - /cli/v6/cli-commands/doctor
+  - /cli/v6/cli-commands/npm-doctor
+  - /cli/v6/commands/doctor
+  - /cli/v6/doctor
+  - /cli/v6/npm-doctor
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-edit.md
+++ b/content/cli/v6/commands/npm-edit.md
@@ -5,6 +5,18 @@ description: Edit an installed package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-edit.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/edit
+  - /cli-documentation/v6/cli-commands/npm-edit
+  - /cli-documentation/v6/commands/edit
+  - /cli-documentation/v6/commands/npm-edit
+  - /cli-documentation/v6/edit
+  - /cli-documentation/v6/npm-edit
+  - /cli/v6/cli-commands/edit
+  - /cli/v6/cli-commands/npm-edit
+  - /cli/v6/commands/edit
+  - /cli/v6/edit
+  - /cli/v6/npm-edit
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-explore.md
+++ b/content/cli/v6/commands/npm-explore.md
@@ -5,6 +5,18 @@ description: Browse an installed package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-explore.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/explore
+  - /cli-documentation/v6/cli-commands/npm-explore
+  - /cli-documentation/v6/commands/explore
+  - /cli-documentation/v6/commands/npm-explore
+  - /cli-documentation/v6/explore
+  - /cli-documentation/v6/npm-explore
+  - /cli/v6/cli-commands/explore
+  - /cli/v6/cli-commands/npm-explore
+  - /cli/v6/commands/explore
+  - /cli/v6/explore
+  - /cli/v6/npm-explore
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-fund.md
+++ b/content/cli/v6/commands/npm-fund.md
@@ -5,6 +5,18 @@ description: Retrieve funding information
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-fund.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/fund
+  - /cli-documentation/v6/cli-commands/npm-fund
+  - /cli-documentation/v6/commands/fund
+  - /cli-documentation/v6/commands/npm-fund
+  - /cli-documentation/v6/fund
+  - /cli-documentation/v6/npm-fund
+  - /cli/v6/cli-commands/fund
+  - /cli/v6/cli-commands/npm-fund
+  - /cli/v6/commands/fund
+  - /cli/v6/fund
+  - /cli/v6/npm-fund
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-help-search.md
+++ b/content/cli/v6/commands/npm-help-search.md
@@ -5,6 +5,18 @@ description: Search npm help documentation
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-help-search.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/help-search
+  - /cli-documentation/v6/cli-commands/npm-help-search
+  - /cli-documentation/v6/commands/help-search
+  - /cli-documentation/v6/commands/npm-help-search
+  - /cli-documentation/v6/help-search
+  - /cli-documentation/v6/npm-help-search
+  - /cli/v6/cli-commands/help-search
+  - /cli/v6/cli-commands/npm-help-search
+  - /cli/v6/commands/help-search
+  - /cli/v6/help-search
+  - /cli/v6/npm-help-search
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-help.md
+++ b/content/cli/v6/commands/npm-help.md
@@ -5,6 +5,18 @@ description: Get help on npm
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-help.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/help
+  - /cli-documentation/v6/cli-commands/npm-help
+  - /cli-documentation/v6/commands/help
+  - /cli-documentation/v6/commands/npm-help
+  - /cli-documentation/v6/help
+  - /cli-documentation/v6/npm-help
+  - /cli/v6/cli-commands/help
+  - /cli/v6/cli-commands/npm-help
+  - /cli/v6/commands/help
+  - /cli/v6/help
+  - /cli/v6/npm-help
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-hook.md
+++ b/content/cli/v6/commands/npm-hook.md
@@ -5,6 +5,18 @@ description: Manage registry hooks
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-hook.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/hook
+  - /cli-documentation/v6/cli-commands/npm-hook
+  - /cli-documentation/v6/commands/hook
+  - /cli-documentation/v6/commands/npm-hook
+  - /cli-documentation/v6/hook
+  - /cli-documentation/v6/npm-hook
+  - /cli/v6/cli-commands/hook
+  - /cli/v6/cli-commands/npm-hook
+  - /cli/v6/commands/hook
+  - /cli/v6/hook
+  - /cli/v6/npm-hook
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-init.md
+++ b/content/cli/v6/commands/npm-init.md
@@ -5,6 +5,18 @@ description: create a package.json file
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-init.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/init
+  - /cli-documentation/v6/cli-commands/npm-init
+  - /cli-documentation/v6/commands/init
+  - /cli-documentation/v6/commands/npm-init
+  - /cli-documentation/v6/init
+  - /cli-documentation/v6/npm-init
+  - /cli/v6/cli-commands/init
+  - /cli/v6/cli-commands/npm-init
+  - /cli/v6/commands/init
+  - /cli/v6/init
+  - /cli/v6/npm-init
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-install-ci-test.md
+++ b/content/cli/v6/commands/npm-install-ci-test.md
@@ -5,6 +5,18 @@ description: Install a project with a clean slate and run tests
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-install-ci-test.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/install-ci-test
+  - /cli-documentation/v6/cli-commands/npm-install-ci-test
+  - /cli-documentation/v6/commands/install-ci-test
+  - /cli-documentation/v6/commands/npm-install-ci-test
+  - /cli-documentation/v6/install-ci-test
+  - /cli-documentation/v6/npm-install-ci-test
+  - /cli/v6/cli-commands/install-ci-test
+  - /cli/v6/cli-commands/npm-install-ci-test
+  - /cli/v6/commands/install-ci-test
+  - /cli/v6/install-ci-test
+  - /cli/v6/npm-install-ci-test
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-install-test.md
+++ b/content/cli/v6/commands/npm-install-test.md
@@ -5,6 +5,18 @@ description: Install package(s) and run tests
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-install-test.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/install-test
+  - /cli-documentation/v6/cli-commands/npm-install-test
+  - /cli-documentation/v6/commands/install-test
+  - /cli-documentation/v6/commands/npm-install-test
+  - /cli-documentation/v6/install-test
+  - /cli-documentation/v6/npm-install-test
+  - /cli/v6/cli-commands/install-test
+  - /cli/v6/cli-commands/npm-install-test
+  - /cli/v6/commands/install-test
+  - /cli/v6/install-test
+  - /cli/v6/npm-install-test
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-install.md
+++ b/content/cli/v6/commands/npm-install.md
@@ -5,6 +5,18 @@ description: Install a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-install.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/install
+  - /cli-documentation/v6/cli-commands/npm-install
+  - /cli-documentation/v6/commands/install
+  - /cli-documentation/v6/commands/npm-install
+  - /cli-documentation/v6/install
+  - /cli-documentation/v6/npm-install
+  - /cli/v6/cli-commands/install
+  - /cli/v6/cli-commands/npm-install
+  - /cli/v6/commands/install
+  - /cli/v6/install
+  - /cli/v6/npm-install
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-link.md
+++ b/content/cli/v6/commands/npm-link.md
@@ -5,6 +5,18 @@ description: Symlink a package folder
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-link.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/link
+  - /cli-documentation/v6/cli-commands/npm-link
+  - /cli-documentation/v6/commands/link
+  - /cli-documentation/v6/commands/npm-link
+  - /cli-documentation/v6/link
+  - /cli-documentation/v6/npm-link
+  - /cli/v6/cli-commands/link
+  - /cli/v6/cli-commands/npm-link
+  - /cli/v6/commands/link
+  - /cli/v6/link
+  - /cli/v6/npm-link
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-logout.md
+++ b/content/cli/v6/commands/npm-logout.md
@@ -5,6 +5,18 @@ description: Log out of the registry
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-logout.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/logout
+  - /cli-documentation/v6/cli-commands/npm-logout
+  - /cli-documentation/v6/commands/logout
+  - /cli-documentation/v6/commands/npm-logout
+  - /cli-documentation/v6/logout
+  - /cli-documentation/v6/npm-logout
+  - /cli/v6/cli-commands/logout
+  - /cli/v6/cli-commands/npm-logout
+  - /cli/v6/commands/logout
+  - /cli/v6/logout
+  - /cli/v6/npm-logout
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-ls.md
+++ b/content/cli/v6/commands/npm-ls.md
@@ -5,6 +5,18 @@ description: List installed packages
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-ls.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/ls
+  - /cli-documentation/v6/cli-commands/npm-ls
+  - /cli-documentation/v6/commands/ls
+  - /cli-documentation/v6/commands/npm-ls
+  - /cli-documentation/v6/ls
+  - /cli-documentation/v6/npm-ls
+  - /cli/v6/cli-commands/ls
+  - /cli/v6/cli-commands/npm-ls
+  - /cli/v6/commands/ls
+  - /cli/v6/ls
+  - /cli/v6/npm-ls
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-org.md
+++ b/content/cli/v6/commands/npm-org.md
@@ -5,6 +5,18 @@ description: Manage orgs
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-org.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-org
+  - /cli-documentation/v6/cli-commands/org
+  - /cli-documentation/v6/commands/npm-org
+  - /cli-documentation/v6/commands/org
+  - /cli-documentation/v6/npm-org
+  - /cli-documentation/v6/org
+  - /cli/v6/cli-commands/npm-org
+  - /cli/v6/cli-commands/org
+  - /cli/v6/commands/org
+  - /cli/v6/npm-org
+  - /cli/v6/org
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-outdated.md
+++ b/content/cli/v6/commands/npm-outdated.md
@@ -5,6 +5,18 @@ description: Check for outdated packages
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-outdated.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-outdated
+  - /cli-documentation/v6/cli-commands/outdated
+  - /cli-documentation/v6/commands/npm-outdated
+  - /cli-documentation/v6/commands/outdated
+  - /cli-documentation/v6/npm-outdated
+  - /cli-documentation/v6/outdated
+  - /cli/v6/cli-commands/npm-outdated
+  - /cli/v6/cli-commands/outdated
+  - /cli/v6/commands/outdated
+  - /cli/v6/npm-outdated
+  - /cli/v6/outdated
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-owner.md
+++ b/content/cli/v6/commands/npm-owner.md
@@ -5,6 +5,18 @@ description: Manage package owners
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-owner.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-owner
+  - /cli-documentation/v6/cli-commands/owner
+  - /cli-documentation/v6/commands/npm-owner
+  - /cli-documentation/v6/commands/owner
+  - /cli-documentation/v6/npm-owner
+  - /cli-documentation/v6/owner
+  - /cli/v6/cli-commands/npm-owner
+  - /cli/v6/cli-commands/owner
+  - /cli/v6/commands/owner
+  - /cli/v6/npm-owner
+  - /cli/v6/owner
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-pack.md
+++ b/content/cli/v6/commands/npm-pack.md
@@ -5,6 +5,18 @@ description: Create a tarball from a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-pack.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-pack
+  - /cli-documentation/v6/cli-commands/pack
+  - /cli-documentation/v6/commands/npm-pack
+  - /cli-documentation/v6/commands/pack
+  - /cli-documentation/v6/npm-pack
+  - /cli-documentation/v6/pack
+  - /cli/v6/cli-commands/npm-pack
+  - /cli/v6/cli-commands/pack
+  - /cli/v6/commands/pack
+  - /cli/v6/npm-pack
+  - /cli/v6/pack
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-ping.md
+++ b/content/cli/v6/commands/npm-ping.md
@@ -5,6 +5,18 @@ description: Ping npm registry
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-ping.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-ping
+  - /cli-documentation/v6/cli-commands/ping
+  - /cli-documentation/v6/commands/npm-ping
+  - /cli-documentation/v6/commands/ping
+  - /cli-documentation/v6/npm-ping
+  - /cli-documentation/v6/ping
+  - /cli/v6/cli-commands/npm-ping
+  - /cli/v6/cli-commands/ping
+  - /cli/v6/commands/ping
+  - /cli/v6/npm-ping
+  - /cli/v6/ping
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-prefix.md
+++ b/content/cli/v6/commands/npm-prefix.md
@@ -5,6 +5,18 @@ description: Display prefix
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-prefix.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-prefix
+  - /cli-documentation/v6/cli-commands/prefix
+  - /cli-documentation/v6/commands/npm-prefix
+  - /cli-documentation/v6/commands/prefix
+  - /cli-documentation/v6/npm-prefix
+  - /cli-documentation/v6/prefix
+  - /cli/v6/cli-commands/npm-prefix
+  - /cli/v6/cli-commands/prefix
+  - /cli/v6/commands/prefix
+  - /cli/v6/npm-prefix
+  - /cli/v6/prefix
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-profile.md
+++ b/content/cli/v6/commands/npm-profile.md
@@ -5,6 +5,18 @@ description: Change settings on your registry profile
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-profile.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-profile
+  - /cli-documentation/v6/cli-commands/profile
+  - /cli-documentation/v6/commands/npm-profile
+  - /cli-documentation/v6/commands/profile
+  - /cli-documentation/v6/npm-profile
+  - /cli-documentation/v6/profile
+  - /cli/v6/cli-commands/npm-profile
+  - /cli/v6/cli-commands/profile
+  - /cli/v6/commands/profile
+  - /cli/v6/npm-profile
+  - /cli/v6/profile
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-prune.md
+++ b/content/cli/v6/commands/npm-prune.md
@@ -5,6 +5,18 @@ description: Remove extraneous packages
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-prune.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-prune
+  - /cli-documentation/v6/cli-commands/prune
+  - /cli-documentation/v6/commands/npm-prune
+  - /cli-documentation/v6/commands/prune
+  - /cli-documentation/v6/npm-prune
+  - /cli-documentation/v6/prune
+  - /cli/v6/cli-commands/npm-prune
+  - /cli/v6/cli-commands/prune
+  - /cli/v6/commands/prune
+  - /cli/v6/npm-prune
+  - /cli/v6/prune
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-publish.md
+++ b/content/cli/v6/commands/npm-publish.md
@@ -5,6 +5,18 @@ description: Publish a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-publish.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-publish
+  - /cli-documentation/v6/cli-commands/publish
+  - /cli-documentation/v6/commands/npm-publish
+  - /cli-documentation/v6/commands/publish
+  - /cli-documentation/v6/npm-publish
+  - /cli-documentation/v6/publish
+  - /cli/v6/cli-commands/npm-publish
+  - /cli/v6/cli-commands/publish
+  - /cli/v6/commands/publish
+  - /cli/v6/npm-publish
+  - /cli/v6/publish
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-rebuild.md
+++ b/content/cli/v6/commands/npm-rebuild.md
@@ -5,6 +5,18 @@ description: Rebuild a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-rebuild.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-rebuild
+  - /cli-documentation/v6/cli-commands/rebuild
+  - /cli-documentation/v6/commands/npm-rebuild
+  - /cli-documentation/v6/commands/rebuild
+  - /cli-documentation/v6/npm-rebuild
+  - /cli-documentation/v6/rebuild
+  - /cli/v6/cli-commands/npm-rebuild
+  - /cli/v6/cli-commands/rebuild
+  - /cli/v6/commands/rebuild
+  - /cli/v6/npm-rebuild
+  - /cli/v6/rebuild
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-repo.md
+++ b/content/cli/v6/commands/npm-repo.md
@@ -5,6 +5,18 @@ description: Open package repository page in the browser
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-repo.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-repo
+  - /cli-documentation/v6/cli-commands/repo
+  - /cli-documentation/v6/commands/npm-repo
+  - /cli-documentation/v6/commands/repo
+  - /cli-documentation/v6/npm-repo
+  - /cli-documentation/v6/repo
+  - /cli/v6/cli-commands/npm-repo
+  - /cli/v6/cli-commands/repo
+  - /cli/v6/commands/repo
+  - /cli/v6/npm-repo
+  - /cli/v6/repo
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-restart.md
+++ b/content/cli/v6/commands/npm-restart.md
@@ -5,6 +5,18 @@ description: Restart a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-restart.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-restart
+  - /cli-documentation/v6/cli-commands/restart
+  - /cli-documentation/v6/commands/npm-restart
+  - /cli-documentation/v6/commands/restart
+  - /cli-documentation/v6/npm-restart
+  - /cli-documentation/v6/restart
+  - /cli/v6/cli-commands/npm-restart
+  - /cli/v6/cli-commands/restart
+  - /cli/v6/commands/restart
+  - /cli/v6/npm-restart
+  - /cli/v6/restart
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-root.md
+++ b/content/cli/v6/commands/npm-root.md
@@ -5,6 +5,18 @@ description: Display npm root
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-root.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-root
+  - /cli-documentation/v6/cli-commands/root
+  - /cli-documentation/v6/commands/npm-root
+  - /cli-documentation/v6/commands/root
+  - /cli-documentation/v6/npm-root
+  - /cli-documentation/v6/root
+  - /cli/v6/cli-commands/npm-root
+  - /cli/v6/cli-commands/root
+  - /cli/v6/commands/root
+  - /cli/v6/npm-root
+  - /cli/v6/root
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-run-script.md
+++ b/content/cli/v6/commands/npm-run-script.md
@@ -5,6 +5,18 @@ description: Run arbitrary package scripts
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-run-script.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-run-script
+  - /cli-documentation/v6/cli-commands/run-script
+  - /cli-documentation/v6/commands/npm-run-script
+  - /cli-documentation/v6/commands/run-script
+  - /cli-documentation/v6/npm-run-script
+  - /cli-documentation/v6/run-script
+  - /cli/v6/cli-commands/npm-run-script
+  - /cli/v6/cli-commands/run-script
+  - /cli/v6/commands/run-script
+  - /cli/v6/npm-run-script
+  - /cli/v6/run-script
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-search.md
+++ b/content/cli/v6/commands/npm-search.md
@@ -5,6 +5,18 @@ description: Search for packages
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-search.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-search
+  - /cli-documentation/v6/cli-commands/search
+  - /cli-documentation/v6/commands/npm-search
+  - /cli-documentation/v6/commands/search
+  - /cli-documentation/v6/npm-search
+  - /cli-documentation/v6/search
+  - /cli/v6/cli-commands/npm-search
+  - /cli/v6/cli-commands/search
+  - /cli/v6/commands/search
+  - /cli/v6/npm-search
+  - /cli/v6/search
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-shrinkwrap.md
+++ b/content/cli/v6/commands/npm-shrinkwrap.md
@@ -5,6 +5,18 @@ description: Lock down dependency versions for publication
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-shrinkwrap.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-shrinkwrap
+  - /cli-documentation/v6/cli-commands/shrinkwrap
+  - /cli-documentation/v6/commands/npm-shrinkwrap
+  - /cli-documentation/v6/commands/shrinkwrap
+  - /cli-documentation/v6/npm-shrinkwrap
+  - /cli-documentation/v6/shrinkwrap
+  - /cli/v6/cli-commands/npm-shrinkwrap
+  - /cli/v6/cli-commands/shrinkwrap
+  - /cli/v6/commands/shrinkwrap
+  - /cli/v6/npm-shrinkwrap
+  - /cli/v6/shrinkwrap
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-star.md
+++ b/content/cli/v6/commands/npm-star.md
@@ -5,6 +5,18 @@ description: Mark your favorite packages
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-star.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-star
+  - /cli-documentation/v6/cli-commands/star
+  - /cli-documentation/v6/commands/npm-star
+  - /cli-documentation/v6/commands/star
+  - /cli-documentation/v6/npm-star
+  - /cli-documentation/v6/star
+  - /cli/v6/cli-commands/npm-star
+  - /cli/v6/cli-commands/star
+  - /cli/v6/commands/star
+  - /cli/v6/npm-star
+  - /cli/v6/star
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-stars.md
+++ b/content/cli/v6/commands/npm-stars.md
@@ -5,6 +5,18 @@ description: View packages marked as favorites
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-stars.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-stars
+  - /cli-documentation/v6/cli-commands/stars
+  - /cli-documentation/v6/commands/npm-stars
+  - /cli-documentation/v6/commands/stars
+  - /cli-documentation/v6/npm-stars
+  - /cli-documentation/v6/stars
+  - /cli/v6/cli-commands/npm-stars
+  - /cli/v6/cli-commands/stars
+  - /cli/v6/commands/stars
+  - /cli/v6/npm-stars
+  - /cli/v6/stars
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-start.md
+++ b/content/cli/v6/commands/npm-start.md
@@ -5,6 +5,18 @@ description: Start a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-start.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-start
+  - /cli-documentation/v6/cli-commands/start
+  - /cli-documentation/v6/commands/npm-start
+  - /cli-documentation/v6/commands/start
+  - /cli-documentation/v6/npm-start
+  - /cli-documentation/v6/start
+  - /cli/v6/cli-commands/npm-start
+  - /cli/v6/cli-commands/start
+  - /cli/v6/commands/start
+  - /cli/v6/npm-start
+  - /cli/v6/start
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-stop.md
+++ b/content/cli/v6/commands/npm-stop.md
@@ -5,6 +5,18 @@ description: Stop a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-stop.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-stop
+  - /cli-documentation/v6/cli-commands/stop
+  - /cli-documentation/v6/commands/npm-stop
+  - /cli-documentation/v6/commands/stop
+  - /cli-documentation/v6/npm-stop
+  - /cli-documentation/v6/stop
+  - /cli/v6/cli-commands/npm-stop
+  - /cli/v6/cli-commands/stop
+  - /cli/v6/commands/stop
+  - /cli/v6/npm-stop
+  - /cli/v6/stop
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-team.md
+++ b/content/cli/v6/commands/npm-team.md
@@ -5,6 +5,18 @@ description: Manage organization teams and team memberships
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-team.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-team
+  - /cli-documentation/v6/cli-commands/team
+  - /cli-documentation/v6/commands/npm-team
+  - /cli-documentation/v6/commands/team
+  - /cli-documentation/v6/npm-team
+  - /cli-documentation/v6/team
+  - /cli/v6/cli-commands/npm-team
+  - /cli/v6/cli-commands/team
+  - /cli/v6/commands/team
+  - /cli/v6/npm-team
+  - /cli/v6/team
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-test.md
+++ b/content/cli/v6/commands/npm-test.md
@@ -5,6 +5,18 @@ description: Test a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-test.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-test
+  - /cli-documentation/v6/cli-commands/test
+  - /cli-documentation/v6/commands/npm-test
+  - /cli-documentation/v6/commands/test
+  - /cli-documentation/v6/npm-test
+  - /cli-documentation/v6/test
+  - /cli/v6/cli-commands/npm-test
+  - /cli/v6/cli-commands/test
+  - /cli/v6/commands/test
+  - /cli/v6/npm-test
+  - /cli/v6/test
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-token.md
+++ b/content/cli/v6/commands/npm-token.md
@@ -5,6 +5,18 @@ description: Manage your authentication tokens
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-token.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-token
+  - /cli-documentation/v6/cli-commands/token
+  - /cli-documentation/v6/commands/npm-token
+  - /cli-documentation/v6/commands/token
+  - /cli-documentation/v6/npm-token
+  - /cli-documentation/v6/token
+  - /cli/v6/cli-commands/npm-token
+  - /cli/v6/cli-commands/token
+  - /cli/v6/commands/token
+  - /cli/v6/npm-token
+  - /cli/v6/token
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-uninstall.md
+++ b/content/cli/v6/commands/npm-uninstall.md
@@ -5,6 +5,18 @@ description: Remove a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-uninstall.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-uninstall
+  - /cli-documentation/v6/cli-commands/uninstall
+  - /cli-documentation/v6/commands/npm-uninstall
+  - /cli-documentation/v6/commands/uninstall
+  - /cli-documentation/v6/npm-uninstall
+  - /cli-documentation/v6/uninstall
+  - /cli/v6/cli-commands/npm-uninstall
+  - /cli/v6/cli-commands/uninstall
+  - /cli/v6/commands/uninstall
+  - /cli/v6/npm-uninstall
+  - /cli/v6/uninstall
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-unpublish.md
+++ b/content/cli/v6/commands/npm-unpublish.md
@@ -5,6 +5,18 @@ description: Remove a package from the registry
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-unpublish.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-unpublish
+  - /cli-documentation/v6/cli-commands/unpublish
+  - /cli-documentation/v6/commands/npm-unpublish
+  - /cli-documentation/v6/commands/unpublish
+  - /cli-documentation/v6/npm-unpublish
+  - /cli-documentation/v6/unpublish
+  - /cli/v6/cli-commands/npm-unpublish
+  - /cli/v6/cli-commands/unpublish
+  - /cli/v6/commands/unpublish
+  - /cli/v6/npm-unpublish
+  - /cli/v6/unpublish
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-update.md
+++ b/content/cli/v6/commands/npm-update.md
@@ -5,6 +5,18 @@ description: Update a package
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-update.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-update
+  - /cli-documentation/v6/cli-commands/update
+  - /cli-documentation/v6/commands/npm-update
+  - /cli-documentation/v6/commands/update
+  - /cli-documentation/v6/npm-update
+  - /cli-documentation/v6/update
+  - /cli/v6/cli-commands/npm-update
+  - /cli/v6/cli-commands/update
+  - /cli/v6/commands/update
+  - /cli/v6/npm-update
+  - /cli/v6/update
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-version.md
+++ b/content/cli/v6/commands/npm-version.md
@@ -5,6 +5,18 @@ description: Bump a package version
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-version.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-version
+  - /cli-documentation/v6/cli-commands/version
+  - /cli-documentation/v6/commands/npm-version
+  - /cli-documentation/v6/commands/version
+  - /cli-documentation/v6/npm-version
+  - /cli-documentation/v6/version
+  - /cli/v6/cli-commands/npm-version
+  - /cli/v6/cli-commands/version
+  - /cli/v6/commands/version
+  - /cli/v6/npm-version
+  - /cli/v6/version
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-view.md
+++ b/content/cli/v6/commands/npm-view.md
@@ -5,6 +5,18 @@ description: View registry info
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-view.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-view
+  - /cli-documentation/v6/cli-commands/view
+  - /cli-documentation/v6/commands/npm-view
+  - /cli-documentation/v6/commands/view
+  - /cli-documentation/v6/npm-view
+  - /cli-documentation/v6/view
+  - /cli/v6/cli-commands/npm-view
+  - /cli/v6/cli-commands/view
+  - /cli/v6/commands/view
+  - /cli/v6/npm-view
+  - /cli/v6/view
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm-whoami.md
+++ b/content/cli/v6/commands/npm-whoami.md
@@ -5,6 +5,18 @@ description: Display npm username
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm-whoami.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm-whoami
+  - /cli-documentation/v6/cli-commands/whoami
+  - /cli-documentation/v6/commands/npm-whoami
+  - /cli-documentation/v6/commands/whoami
+  - /cli-documentation/v6/npm-whoami
+  - /cli-documentation/v6/whoami
+  - /cli/v6/cli-commands/npm-whoami
+  - /cli/v6/cli-commands/whoami
+  - /cli/v6/commands/whoami
+  - /cli/v6/npm-whoami
+  - /cli/v6/whoami
 ---
 
 ### Synopsis

--- a/content/cli/v6/commands/npm.md
+++ b/content/cli/v6/commands/npm.md
@@ -5,6 +5,12 @@ description: javascript package manager
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/commands/npm.md
+redirect_from:
+  - /cli-documentation/v6/cli-commands/npm
+  - /cli-documentation/v6/commands/npm
+  - /cli-documentation/v6/npm
+  - /cli/v6/cli-commands/npm
+  - /cli/v6/npm
 ---
 
 ### Synopsis

--- a/content/cli/v6/configuring-npm/folders.md
+++ b/content/cli/v6/configuring-npm/folders.md
@@ -5,6 +5,10 @@ description: Folder Structures Used by npm
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/configuring-npm/folders.md
+redirect_from:
+  - /cli-documentation/v6/configuring-npm/folders
+  - /cli-documentation/v6/files/folders
+  - /cli/v6/files/folders
 ---
 
 ### Description

--- a/content/cli/v6/configuring-npm/index.mdx
+++ b/content/cli/v6/configuring-npm/index.mdx
@@ -3,6 +3,14 @@ title: Configuring npm
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v6/configuring-npm
+  - /cli-documentation/v6/configuring-npm/index
+  - /cli-documentation/v6/files
+  - /cli-documentation/v6/files/index
+  - /cli/v6/configuring-npm/index
+  - /cli/v6/files
+  - /cli/v6/files/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v6/configuring-npm/install.md
+++ b/content/cli/v6/configuring-npm/install.md
@@ -5,6 +5,10 @@ description: Download and install node and npm
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/configuring-npm/install.md
+redirect_from:
+  - /cli-documentation/v6/configuring-npm/install
+  - /cli-documentation/v6/files/install
+  - /cli/v6/files/install
 ---
 
 ### Description

--- a/content/cli/v6/configuring-npm/npmrc.md
+++ b/content/cli/v6/configuring-npm/npmrc.md
@@ -5,6 +5,10 @@ description: The npm config files
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/configuring-npm/npmrc.md
+redirect_from:
+  - /cli-documentation/v6/configuring-npm/npmrc
+  - /cli-documentation/v6/files/npmrc
+  - /cli/v6/files/npmrc
 ---
 
 ### Description

--- a/content/cli/v6/configuring-npm/package-json.md
+++ b/content/cli/v6/configuring-npm/package-json.md
@@ -5,6 +5,14 @@ description: Specifics of npm's package.json handling
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/configuring-npm/package-json.md
+redirect_from:
+  - /cli-documentation/v6/configuring-npm/package-json
+  - /cli-documentation/v6/configuring-npm/package.json
+  - /cli-documentation/v6/files/package-json
+  - /cli-documentation/v6/files/package.json
+  - /cli/v6/configuring-npm/package.json
+  - /cli/v6/files/package-json
+  - /cli/v6/files/package.json
 ---
 
 ### Description

--- a/content/cli/v6/configuring-npm/package-lock-json.md
+++ b/content/cli/v6/configuring-npm/package-lock-json.md
@@ -5,6 +5,14 @@ description: A manifestation of the manifest
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/configuring-npm/package-lock-json.md
+redirect_from:
+  - /cli-documentation/v6/configuring-npm/package-lock-json
+  - /cli-documentation/v6/configuring-npm/package-lock.json
+  - /cli-documentation/v6/files/package-lock-json
+  - /cli-documentation/v6/files/package-lock.json
+  - /cli/v6/configuring-npm/package-lock.json
+  - /cli/v6/files/package-lock-json
+  - /cli/v6/files/package-lock.json
 ---
 
 ### Description

--- a/content/cli/v6/configuring-npm/package-locks.md
+++ b/content/cli/v6/configuring-npm/package-locks.md
@@ -5,6 +5,11 @@ description: An explanation of npm lockfiles
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/configuring-npm/package-locks.md
+redirect_from:
+  - /cli-documentation/v6/configuring-npm/package-locks
+  - /cli-documentation/v6/files/package-locks
+  - /cli/v6/files/package-locks
+  - /configuring-npm/package-locks
 ---
 
 ### Description

--- a/content/cli/v6/configuring-npm/shrinkwrap-json.md
+++ b/content/cli/v6/configuring-npm/shrinkwrap-json.md
@@ -5,6 +5,14 @@ description: A publishable lockfile
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/configuring-npm/shrinkwrap-json.md
+redirect_from:
+  - /cli-documentation/v6/configuring-npm/shrinkwrap-json
+  - /cli-documentation/v6/configuring-npm/shrinkwrap.json
+  - /cli-documentation/v6/files/shrinkwrap-json
+  - /cli-documentation/v6/files/shrinkwrap.json
+  - /cli/v6/configuring-npm/shrinkwrap.json
+  - /cli/v6/files/shrinkwrap-json
+  - /cli/v6/files/shrinkwrap.json
 ---
 
 ### Description

--- a/content/cli/v6/index.mdx
+++ b/content/cli/v6/index.mdx
@@ -3,6 +3,10 @@ title: npm CLI
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v6
+  - /cli-documentation/v6/index
+  - /cli/v6/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v6/using-npm/config.md
+++ b/content/cli/v6/using-npm/config.md
@@ -5,6 +5,10 @@ description: More than you probably want to know about npm configuration
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/config.md
+redirect_from:
+  - /cli-documentation/v6/misc/config
+  - /cli-documentation/v6/using-npm/config
+  - /cli/v6/misc/config
 ---
 
 ### Description

--- a/content/cli/v6/using-npm/developers.md
+++ b/content/cli/v6/using-npm/developers.md
@@ -5,6 +5,10 @@ description: Developer Guide
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/developers.md
+redirect_from:
+  - /cli-documentation/v6/misc/developers
+  - /cli-documentation/v6/using-npm/developers
+  - /cli/v6/misc/developers
 ---
 
 ### Description

--- a/content/cli/v6/using-npm/index.mdx
+++ b/content/cli/v6/using-npm/index.mdx
@@ -3,6 +3,14 @@ title: Using npm
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v6/misc
+  - /cli-documentation/v6/misc/index
+  - /cli-documentation/v6/using-npm
+  - /cli-documentation/v6/using-npm/index
+  - /cli/v6/misc
+  - /cli/v6/misc/index
+  - /cli/v6/using-npm/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v6/using-npm/orgs.md
+++ b/content/cli/v6/using-npm/orgs.md
@@ -5,6 +5,10 @@ description: Working with Teams & Orgs
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/orgs.md
+redirect_from:
+  - /cli-documentation/v6/misc/orgs
+  - /cli-documentation/v6/using-npm/orgs
+  - /cli/v6/misc/orgs
 ---
 
 ### Description

--- a/content/cli/v6/using-npm/registry.md
+++ b/content/cli/v6/using-npm/registry.md
@@ -5,6 +5,10 @@ description: The JavaScript Package Registry
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/registry.md
+redirect_from:
+  - /cli-documentation/v6/misc/registry
+  - /cli-documentation/v6/using-npm/registry
+  - /cli/v6/misc/registry
 ---
 
 ### Description

--- a/content/cli/v6/using-npm/removal.md
+++ b/content/cli/v6/using-npm/removal.md
@@ -5,6 +5,14 @@ description: Cleaning the Slate
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/removal.md
+redirect_from:
+  - /cli-documentation/v6/misc/removal
+  - /cli-documentation/v6/misc/removing-npm
+  - /cli-documentation/v6/using-npm/removal
+  - /cli-documentation/v6/using-npm/removing-npm
+  - /cli/v6/misc/removal
+  - /cli/v6/misc/removing-npm
+  - /cli/v6/using-npm/removing-npm
 ---
 
 ### Synopsis

--- a/content/cli/v6/using-npm/scope.md
+++ b/content/cli/v6/using-npm/scope.md
@@ -5,6 +5,14 @@ description: Scoped packages
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/scope.md
+redirect_from:
+  - /cli-documentation/v6/misc/npm-scope
+  - /cli-documentation/v6/misc/scope
+  - /cli-documentation/v6/using-npm/npm-scope
+  - /cli-documentation/v6/using-npm/scope
+  - /cli/v6/misc/npm-scope
+  - /cli/v6/misc/scope
+  - /cli/v6/using-npm/npm-scope
 ---
 
 ### Description

--- a/content/cli/v6/using-npm/scripts.md
+++ b/content/cli/v6/using-npm/scripts.md
@@ -5,6 +5,10 @@ description: How npm handles the "scripts" field
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/scripts.md
+redirect_from:
+  - /cli-documentation/v6/misc/scripts
+  - /cli-documentation/v6/using-npm/scripts
+  - /cli/v6/misc/scripts
 ---
 
 ### Description

--- a/content/cli/v6/using-npm/semver.md
+++ b/content/cli/v6/using-npm/semver.md
@@ -5,6 +5,10 @@ description: The semantic versioner for npm
 github_repo: npm/cli
 github_branch: v6
 github_path: docs/content/using-npm/semver.md
+redirect_from:
+  - /cli-documentation/v6/misc/semver
+  - /cli-documentation/v6/using-npm/semver
+  - /cli/v6/misc/semver
 ---
 
 ## Install

--- a/content/cli/v7/commands/index.mdx
+++ b/content/cli/v7/commands/index.mdx
@@ -3,6 +3,14 @@ title: CLI Commands
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v7/cli-commands
+  - /cli-documentation/v7/cli-commands/index
+  - /cli-documentation/v7/commands
+  - /cli-documentation/v7/commands/index
+  - /cli/v7/cli-commands
+  - /cli/v7/cli-commands/index
+  - /cli/v7/commands/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v7/commands/npm-access.md
+++ b/content/cli/v7/commands/npm-access.md
@@ -5,6 +5,18 @@ description: Set access level on published packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-access.md
+redirect_from:
+  - /cli-documentation/v7/access
+  - /cli-documentation/v7/cli-commands/access
+  - /cli-documentation/v7/cli-commands/npm-access
+  - /cli-documentation/v7/commands/access
+  - /cli-documentation/v7/commands/npm-access
+  - /cli-documentation/v7/npm-access
+  - /cli/v7/access
+  - /cli/v7/cli-commands/access
+  - /cli/v7/cli-commands/npm-access
+  - /cli/v7/commands/access
+  - /cli/v7/npm-access
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-adduser.md
+++ b/content/cli/v7/commands/npm-adduser.md
@@ -5,6 +5,18 @@ description: Add a registry user account
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-adduser.md
+redirect_from:
+  - /cli-documentation/v7/adduser
+  - /cli-documentation/v7/cli-commands/adduser
+  - /cli-documentation/v7/cli-commands/npm-adduser
+  - /cli-documentation/v7/commands/adduser
+  - /cli-documentation/v7/commands/npm-adduser
+  - /cli-documentation/v7/npm-adduser
+  - /cli/v7/adduser
+  - /cli/v7/cli-commands/adduser
+  - /cli/v7/cli-commands/npm-adduser
+  - /cli/v7/commands/adduser
+  - /cli/v7/npm-adduser
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-audit.md
+++ b/content/cli/v7/commands/npm-audit.md
@@ -5,6 +5,18 @@ description: Run a security audit
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-audit.md
+redirect_from:
+  - /cli-documentation/v7/audit
+  - /cli-documentation/v7/cli-commands/audit
+  - /cli-documentation/v7/cli-commands/npm-audit
+  - /cli-documentation/v7/commands/audit
+  - /cli-documentation/v7/commands/npm-audit
+  - /cli-documentation/v7/npm-audit
+  - /cli/v7/audit
+  - /cli/v7/cli-commands/audit
+  - /cli/v7/cli-commands/npm-audit
+  - /cli/v7/commands/audit
+  - /cli/v7/npm-audit
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-bin.md
+++ b/content/cli/v7/commands/npm-bin.md
@@ -5,6 +5,18 @@ description: Display npm bin folder
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-bin.md
+redirect_from:
+  - /cli-documentation/v7/bin
+  - /cli-documentation/v7/cli-commands/bin
+  - /cli-documentation/v7/cli-commands/npm-bin
+  - /cli-documentation/v7/commands/bin
+  - /cli-documentation/v7/commands/npm-bin
+  - /cli-documentation/v7/npm-bin
+  - /cli/v7/bin
+  - /cli/v7/cli-commands/bin
+  - /cli/v7/cli-commands/npm-bin
+  - /cli/v7/commands/bin
+  - /cli/v7/npm-bin
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-bugs.md
+++ b/content/cli/v7/commands/npm-bugs.md
@@ -5,6 +5,18 @@ description: Report bugs for a package in a web browser
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-bugs.md
+redirect_from:
+  - /cli-documentation/v7/bugs
+  - /cli-documentation/v7/cli-commands/bugs
+  - /cli-documentation/v7/cli-commands/npm-bugs
+  - /cli-documentation/v7/commands/bugs
+  - /cli-documentation/v7/commands/npm-bugs
+  - /cli-documentation/v7/npm-bugs
+  - /cli/v7/bugs
+  - /cli/v7/cli-commands/bugs
+  - /cli/v7/cli-commands/npm-bugs
+  - /cli/v7/commands/bugs
+  - /cli/v7/npm-bugs
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-cache.md
+++ b/content/cli/v7/commands/npm-cache.md
@@ -5,6 +5,18 @@ description: Manipulates packages cache
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-cache.md
+redirect_from:
+  - /cli-documentation/v7/cache
+  - /cli-documentation/v7/cli-commands/cache
+  - /cli-documentation/v7/cli-commands/npm-cache
+  - /cli-documentation/v7/commands/cache
+  - /cli-documentation/v7/commands/npm-cache
+  - /cli-documentation/v7/npm-cache
+  - /cli/v7/cache
+  - /cli/v7/cli-commands/cache
+  - /cli/v7/cli-commands/npm-cache
+  - /cli/v7/commands/cache
+  - /cli/v7/npm-cache
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-ci.md
+++ b/content/cli/v7/commands/npm-ci.md
@@ -5,6 +5,18 @@ description: Install a project with a clean slate
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-ci.md
+redirect_from:
+  - /cli-documentation/v7/ci
+  - /cli-documentation/v7/cli-commands/ci
+  - /cli-documentation/v7/cli-commands/npm-ci
+  - /cli-documentation/v7/commands/ci
+  - /cli-documentation/v7/commands/npm-ci
+  - /cli-documentation/v7/npm-ci
+  - /cli/v7/ci
+  - /cli/v7/cli-commands/ci
+  - /cli/v7/cli-commands/npm-ci
+  - /cli/v7/commands/ci
+  - /cli/v7/npm-ci
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-completion.md
+++ b/content/cli/v7/commands/npm-completion.md
@@ -5,6 +5,18 @@ description: Tab Completion for npm
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-completion.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/completion
+  - /cli-documentation/v7/cli-commands/npm-completion
+  - /cli-documentation/v7/commands/completion
+  - /cli-documentation/v7/commands/npm-completion
+  - /cli-documentation/v7/completion
+  - /cli-documentation/v7/npm-completion
+  - /cli/v7/cli-commands/completion
+  - /cli/v7/cli-commands/npm-completion
+  - /cli/v7/commands/completion
+  - /cli/v7/completion
+  - /cli/v7/npm-completion
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-config.md
+++ b/content/cli/v7/commands/npm-config.md
@@ -5,6 +5,18 @@ description: Manage the npm configuration files
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-config.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/config
+  - /cli-documentation/v7/cli-commands/npm-config
+  - /cli-documentation/v7/commands/config
+  - /cli-documentation/v7/commands/npm-config
+  - /cli-documentation/v7/config
+  - /cli-documentation/v7/npm-config
+  - /cli/v7/cli-commands/config
+  - /cli/v7/cli-commands/npm-config
+  - /cli/v7/commands/config
+  - /cli/v7/config
+  - /cli/v7/npm-config
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-dedupe.md
+++ b/content/cli/v7/commands/npm-dedupe.md
@@ -5,6 +5,18 @@ description: Reduce duplication in the package tree
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-dedupe.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/dedupe
+  - /cli-documentation/v7/cli-commands/npm-dedupe
+  - /cli-documentation/v7/commands/dedupe
+  - /cli-documentation/v7/commands/npm-dedupe
+  - /cli-documentation/v7/dedupe
+  - /cli-documentation/v7/npm-dedupe
+  - /cli/v7/cli-commands/dedupe
+  - /cli/v7/cli-commands/npm-dedupe
+  - /cli/v7/commands/dedupe
+  - /cli/v7/dedupe
+  - /cli/v7/npm-dedupe
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-deprecate.md
+++ b/content/cli/v7/commands/npm-deprecate.md
@@ -5,6 +5,18 @@ description: Deprecate a version of a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-deprecate.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/deprecate
+  - /cli-documentation/v7/cli-commands/npm-deprecate
+  - /cli-documentation/v7/commands/deprecate
+  - /cli-documentation/v7/commands/npm-deprecate
+  - /cli-documentation/v7/deprecate
+  - /cli-documentation/v7/npm-deprecate
+  - /cli/v7/cli-commands/deprecate
+  - /cli/v7/cli-commands/npm-deprecate
+  - /cli/v7/commands/deprecate
+  - /cli/v7/deprecate
+  - /cli/v7/npm-deprecate
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-diff.md
+++ b/content/cli/v7/commands/npm-diff.md
@@ -5,6 +5,18 @@ description: The registry diff command
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-diff.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/diff
+  - /cli-documentation/v7/cli-commands/npm-diff
+  - /cli-documentation/v7/commands/diff
+  - /cli-documentation/v7/commands/npm-diff
+  - /cli-documentation/v7/diff
+  - /cli-documentation/v7/npm-diff
+  - /cli/v7/cli-commands/diff
+  - /cli/v7/cli-commands/npm-diff
+  - /cli/v7/commands/diff
+  - /cli/v7/diff
+  - /cli/v7/npm-diff
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-dist-tag.md
+++ b/content/cli/v7/commands/npm-dist-tag.md
@@ -5,6 +5,18 @@ description: Modify package distribution tags
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-dist-tag.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/dist-tag
+  - /cli-documentation/v7/cli-commands/npm-dist-tag
+  - /cli-documentation/v7/commands/dist-tag
+  - /cli-documentation/v7/commands/npm-dist-tag
+  - /cli-documentation/v7/dist-tag
+  - /cli-documentation/v7/npm-dist-tag
+  - /cli/v7/cli-commands/dist-tag
+  - /cli/v7/cli-commands/npm-dist-tag
+  - /cli/v7/commands/dist-tag
+  - /cli/v7/dist-tag
+  - /cli/v7/npm-dist-tag
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-docs.md
+++ b/content/cli/v7/commands/npm-docs.md
@@ -5,6 +5,18 @@ description: Open documentation for a package in a web browser
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-docs.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/docs
+  - /cli-documentation/v7/cli-commands/npm-docs
+  - /cli-documentation/v7/commands/docs
+  - /cli-documentation/v7/commands/npm-docs
+  - /cli-documentation/v7/docs
+  - /cli-documentation/v7/npm-docs
+  - /cli/v7/cli-commands/docs
+  - /cli/v7/cli-commands/npm-docs
+  - /cli/v7/commands/docs
+  - /cli/v7/docs
+  - /cli/v7/npm-docs
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-doctor.md
+++ b/content/cli/v7/commands/npm-doctor.md
@@ -5,6 +5,18 @@ description: Check your npm environment
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-doctor.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/doctor
+  - /cli-documentation/v7/cli-commands/npm-doctor
+  - /cli-documentation/v7/commands/doctor
+  - /cli-documentation/v7/commands/npm-doctor
+  - /cli-documentation/v7/doctor
+  - /cli-documentation/v7/npm-doctor
+  - /cli/v7/cli-commands/doctor
+  - /cli/v7/cli-commands/npm-doctor
+  - /cli/v7/commands/doctor
+  - /cli/v7/doctor
+  - /cli/v7/npm-doctor
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-edit.md
+++ b/content/cli/v7/commands/npm-edit.md
@@ -5,6 +5,18 @@ description: Edit an installed package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-edit.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/edit
+  - /cli-documentation/v7/cli-commands/npm-edit
+  - /cli-documentation/v7/commands/edit
+  - /cli-documentation/v7/commands/npm-edit
+  - /cli-documentation/v7/edit
+  - /cli-documentation/v7/npm-edit
+  - /cli/v7/cli-commands/edit
+  - /cli/v7/cli-commands/npm-edit
+  - /cli/v7/commands/edit
+  - /cli/v7/edit
+  - /cli/v7/npm-edit
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-exec.md
+++ b/content/cli/v7/commands/npm-exec.md
@@ -5,6 +5,18 @@ description: Run a command from a local or remote npm package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-exec.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/exec
+  - /cli-documentation/v7/cli-commands/npm-exec
+  - /cli-documentation/v7/commands/exec
+  - /cli-documentation/v7/commands/npm-exec
+  - /cli-documentation/v7/exec
+  - /cli-documentation/v7/npm-exec
+  - /cli/v7/cli-commands/exec
+  - /cli/v7/cli-commands/npm-exec
+  - /cli/v7/commands/exec
+  - /cli/v7/exec
+  - /cli/v7/npm-exec
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-explain.md
+++ b/content/cli/v7/commands/npm-explain.md
@@ -5,6 +5,18 @@ description: Explain installed packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-explain.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/explain
+  - /cli-documentation/v7/cli-commands/npm-explain
+  - /cli-documentation/v7/commands/explain
+  - /cli-documentation/v7/commands/npm-explain
+  - /cli-documentation/v7/explain
+  - /cli-documentation/v7/npm-explain
+  - /cli/v7/cli-commands/explain
+  - /cli/v7/cli-commands/npm-explain
+  - /cli/v7/commands/explain
+  - /cli/v7/explain
+  - /cli/v7/npm-explain
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-explore.md
+++ b/content/cli/v7/commands/npm-explore.md
@@ -5,6 +5,18 @@ description: Browse an installed package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-explore.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/explore
+  - /cli-documentation/v7/cli-commands/npm-explore
+  - /cli-documentation/v7/commands/explore
+  - /cli-documentation/v7/commands/npm-explore
+  - /cli-documentation/v7/explore
+  - /cli-documentation/v7/npm-explore
+  - /cli/v7/cli-commands/explore
+  - /cli/v7/cli-commands/npm-explore
+  - /cli/v7/commands/explore
+  - /cli/v7/explore
+  - /cli/v7/npm-explore
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-find-dupes.md
+++ b/content/cli/v7/commands/npm-find-dupes.md
@@ -5,6 +5,18 @@ description: Find duplication in the package tree
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-find-dupes.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/find-dupes
+  - /cli-documentation/v7/cli-commands/npm-find-dupes
+  - /cli-documentation/v7/commands/find-dupes
+  - /cli-documentation/v7/commands/npm-find-dupes
+  - /cli-documentation/v7/find-dupes
+  - /cli-documentation/v7/npm-find-dupes
+  - /cli/v7/cli-commands/find-dupes
+  - /cli/v7/cli-commands/npm-find-dupes
+  - /cli/v7/commands/find-dupes
+  - /cli/v7/find-dupes
+  - /cli/v7/npm-find-dupes
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-fund.md
+++ b/content/cli/v7/commands/npm-fund.md
@@ -5,6 +5,18 @@ description: Retrieve funding information
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-fund.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/fund
+  - /cli-documentation/v7/cli-commands/npm-fund
+  - /cli-documentation/v7/commands/fund
+  - /cli-documentation/v7/commands/npm-fund
+  - /cli-documentation/v7/fund
+  - /cli-documentation/v7/npm-fund
+  - /cli/v7/cli-commands/fund
+  - /cli/v7/cli-commands/npm-fund
+  - /cli/v7/commands/fund
+  - /cli/v7/fund
+  - /cli/v7/npm-fund
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-help-search.md
+++ b/content/cli/v7/commands/npm-help-search.md
@@ -5,6 +5,18 @@ description: Search npm help documentation
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-help-search.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/help-search
+  - /cli-documentation/v7/cli-commands/npm-help-search
+  - /cli-documentation/v7/commands/help-search
+  - /cli-documentation/v7/commands/npm-help-search
+  - /cli-documentation/v7/help-search
+  - /cli-documentation/v7/npm-help-search
+  - /cli/v7/cli-commands/help-search
+  - /cli/v7/cli-commands/npm-help-search
+  - /cli/v7/commands/help-search
+  - /cli/v7/help-search
+  - /cli/v7/npm-help-search
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-help.md
+++ b/content/cli/v7/commands/npm-help.md
@@ -5,6 +5,18 @@ description: Get help on npm
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-help.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/help
+  - /cli-documentation/v7/cli-commands/npm-help
+  - /cli-documentation/v7/commands/help
+  - /cli-documentation/v7/commands/npm-help
+  - /cli-documentation/v7/help
+  - /cli-documentation/v7/npm-help
+  - /cli/v7/cli-commands/help
+  - /cli/v7/cli-commands/npm-help
+  - /cli/v7/commands/help
+  - /cli/v7/help
+  - /cli/v7/npm-help
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-hook.md
+++ b/content/cli/v7/commands/npm-hook.md
@@ -5,6 +5,18 @@ description: Manage registry hooks
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-hook.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/hook
+  - /cli-documentation/v7/cli-commands/npm-hook
+  - /cli-documentation/v7/commands/hook
+  - /cli-documentation/v7/commands/npm-hook
+  - /cli-documentation/v7/hook
+  - /cli-documentation/v7/npm-hook
+  - /cli/v7/cli-commands/hook
+  - /cli/v7/cli-commands/npm-hook
+  - /cli/v7/commands/hook
+  - /cli/v7/hook
+  - /cli/v7/npm-hook
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-init.md
+++ b/content/cli/v7/commands/npm-init.md
@@ -5,6 +5,18 @@ description: Create a package.json file
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-init.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/init
+  - /cli-documentation/v7/cli-commands/npm-init
+  - /cli-documentation/v7/commands/init
+  - /cli-documentation/v7/commands/npm-init
+  - /cli-documentation/v7/init
+  - /cli-documentation/v7/npm-init
+  - /cli/v7/cli-commands/init
+  - /cli/v7/cli-commands/npm-init
+  - /cli/v7/commands/init
+  - /cli/v7/init
+  - /cli/v7/npm-init
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-install-ci-test.md
+++ b/content/cli/v7/commands/npm-install-ci-test.md
@@ -5,6 +5,18 @@ description: Install a project with a clean slate and run tests
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-install-ci-test.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/install-ci-test
+  - /cli-documentation/v7/cli-commands/npm-install-ci-test
+  - /cli-documentation/v7/commands/install-ci-test
+  - /cli-documentation/v7/commands/npm-install-ci-test
+  - /cli-documentation/v7/install-ci-test
+  - /cli-documentation/v7/npm-install-ci-test
+  - /cli/v7/cli-commands/install-ci-test
+  - /cli/v7/cli-commands/npm-install-ci-test
+  - /cli/v7/commands/install-ci-test
+  - /cli/v7/install-ci-test
+  - /cli/v7/npm-install-ci-test
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-install-test.md
+++ b/content/cli/v7/commands/npm-install-test.md
@@ -5,6 +5,18 @@ description: Install package(s) and run tests
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-install-test.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/install-test
+  - /cli-documentation/v7/cli-commands/npm-install-test
+  - /cli-documentation/v7/commands/install-test
+  - /cli-documentation/v7/commands/npm-install-test
+  - /cli-documentation/v7/install-test
+  - /cli-documentation/v7/npm-install-test
+  - /cli/v7/cli-commands/install-test
+  - /cli/v7/cli-commands/npm-install-test
+  - /cli/v7/commands/install-test
+  - /cli/v7/install-test
+  - /cli/v7/npm-install-test
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-install.md
+++ b/content/cli/v7/commands/npm-install.md
@@ -5,6 +5,18 @@ description: Install a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-install.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/install
+  - /cli-documentation/v7/cli-commands/npm-install
+  - /cli-documentation/v7/commands/install
+  - /cli-documentation/v7/commands/npm-install
+  - /cli-documentation/v7/install
+  - /cli-documentation/v7/npm-install
+  - /cli/v7/cli-commands/install
+  - /cli/v7/cli-commands/npm-install
+  - /cli/v7/commands/install
+  - /cli/v7/install
+  - /cli/v7/npm-install
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-link.md
+++ b/content/cli/v7/commands/npm-link.md
@@ -5,6 +5,18 @@ description: Symlink a package folder
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-link.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/link
+  - /cli-documentation/v7/cli-commands/npm-link
+  - /cli-documentation/v7/commands/link
+  - /cli-documentation/v7/commands/npm-link
+  - /cli-documentation/v7/link
+  - /cli-documentation/v7/npm-link
+  - /cli/v7/cli-commands/link
+  - /cli/v7/cli-commands/npm-link
+  - /cli/v7/commands/link
+  - /cli/v7/link
+  - /cli/v7/npm-link
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-logout.md
+++ b/content/cli/v7/commands/npm-logout.md
@@ -5,6 +5,18 @@ description: Log out of the registry
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-logout.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/logout
+  - /cli-documentation/v7/cli-commands/npm-logout
+  - /cli-documentation/v7/commands/logout
+  - /cli-documentation/v7/commands/npm-logout
+  - /cli-documentation/v7/logout
+  - /cli-documentation/v7/npm-logout
+  - /cli/v7/cli-commands/logout
+  - /cli/v7/cli-commands/npm-logout
+  - /cli/v7/commands/logout
+  - /cli/v7/logout
+  - /cli/v7/npm-logout
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-ls.md
+++ b/content/cli/v7/commands/npm-ls.md
@@ -5,6 +5,18 @@ description: List installed packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-ls.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/ls
+  - /cli-documentation/v7/cli-commands/npm-ls
+  - /cli-documentation/v7/commands/ls
+  - /cli-documentation/v7/commands/npm-ls
+  - /cli-documentation/v7/ls
+  - /cli-documentation/v7/npm-ls
+  - /cli/v7/cli-commands/ls
+  - /cli/v7/cli-commands/npm-ls
+  - /cli/v7/commands/ls
+  - /cli/v7/ls
+  - /cli/v7/npm-ls
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-org.md
+++ b/content/cli/v7/commands/npm-org.md
@@ -5,6 +5,18 @@ description: Manage orgs
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-org.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-org
+  - /cli-documentation/v7/cli-commands/org
+  - /cli-documentation/v7/commands/npm-org
+  - /cli-documentation/v7/commands/org
+  - /cli-documentation/v7/npm-org
+  - /cli-documentation/v7/org
+  - /cli/v7/cli-commands/npm-org
+  - /cli/v7/cli-commands/org
+  - /cli/v7/commands/org
+  - /cli/v7/npm-org
+  - /cli/v7/org
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-outdated.md
+++ b/content/cli/v7/commands/npm-outdated.md
@@ -5,6 +5,18 @@ description: Check for outdated packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-outdated.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-outdated
+  - /cli-documentation/v7/cli-commands/outdated
+  - /cli-documentation/v7/commands/npm-outdated
+  - /cli-documentation/v7/commands/outdated
+  - /cli-documentation/v7/npm-outdated
+  - /cli-documentation/v7/outdated
+  - /cli/v7/cli-commands/npm-outdated
+  - /cli/v7/cli-commands/outdated
+  - /cli/v7/commands/outdated
+  - /cli/v7/npm-outdated
+  - /cli/v7/outdated
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-owner.md
+++ b/content/cli/v7/commands/npm-owner.md
@@ -5,6 +5,18 @@ description: Manage package owners
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-owner.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-owner
+  - /cli-documentation/v7/cli-commands/owner
+  - /cli-documentation/v7/commands/npm-owner
+  - /cli-documentation/v7/commands/owner
+  - /cli-documentation/v7/npm-owner
+  - /cli-documentation/v7/owner
+  - /cli/v7/cli-commands/npm-owner
+  - /cli/v7/cli-commands/owner
+  - /cli/v7/commands/owner
+  - /cli/v7/npm-owner
+  - /cli/v7/owner
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-pack.md
+++ b/content/cli/v7/commands/npm-pack.md
@@ -5,6 +5,18 @@ description: Create a tarball from a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-pack.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-pack
+  - /cli-documentation/v7/cli-commands/pack
+  - /cli-documentation/v7/commands/npm-pack
+  - /cli-documentation/v7/commands/pack
+  - /cli-documentation/v7/npm-pack
+  - /cli-documentation/v7/pack
+  - /cli/v7/cli-commands/npm-pack
+  - /cli/v7/cli-commands/pack
+  - /cli/v7/commands/pack
+  - /cli/v7/npm-pack
+  - /cli/v7/pack
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-ping.md
+++ b/content/cli/v7/commands/npm-ping.md
@@ -5,6 +5,18 @@ description: Ping npm registry
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-ping.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-ping
+  - /cli-documentation/v7/cli-commands/ping
+  - /cli-documentation/v7/commands/npm-ping
+  - /cli-documentation/v7/commands/ping
+  - /cli-documentation/v7/npm-ping
+  - /cli-documentation/v7/ping
+  - /cli/v7/cli-commands/npm-ping
+  - /cli/v7/cli-commands/ping
+  - /cli/v7/commands/ping
+  - /cli/v7/npm-ping
+  - /cli/v7/ping
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-pkg.md
+++ b/content/cli/v7/commands/npm-pkg.md
@@ -5,6 +5,18 @@ description: Manages your package.json
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-pkg.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-pkg
+  - /cli-documentation/v7/cli-commands/pkg
+  - /cli-documentation/v7/commands/npm-pkg
+  - /cli-documentation/v7/commands/pkg
+  - /cli-documentation/v7/npm-pkg
+  - /cli-documentation/v7/pkg
+  - /cli/v7/cli-commands/npm-pkg
+  - /cli/v7/cli-commands/pkg
+  - /cli/v7/commands/pkg
+  - /cli/v7/npm-pkg
+  - /cli/v7/pkg
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-prefix.md
+++ b/content/cli/v7/commands/npm-prefix.md
@@ -5,6 +5,18 @@ description: Display prefix
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-prefix.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-prefix
+  - /cli-documentation/v7/cli-commands/prefix
+  - /cli-documentation/v7/commands/npm-prefix
+  - /cli-documentation/v7/commands/prefix
+  - /cli-documentation/v7/npm-prefix
+  - /cli-documentation/v7/prefix
+  - /cli/v7/cli-commands/npm-prefix
+  - /cli/v7/cli-commands/prefix
+  - /cli/v7/commands/prefix
+  - /cli/v7/npm-prefix
+  - /cli/v7/prefix
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-profile.md
+++ b/content/cli/v7/commands/npm-profile.md
@@ -5,6 +5,18 @@ description: Change settings on your registry profile
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-profile.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-profile
+  - /cli-documentation/v7/cli-commands/profile
+  - /cli-documentation/v7/commands/npm-profile
+  - /cli-documentation/v7/commands/profile
+  - /cli-documentation/v7/npm-profile
+  - /cli-documentation/v7/profile
+  - /cli/v7/cli-commands/npm-profile
+  - /cli/v7/cli-commands/profile
+  - /cli/v7/commands/profile
+  - /cli/v7/npm-profile
+  - /cli/v7/profile
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-prune.md
+++ b/content/cli/v7/commands/npm-prune.md
@@ -5,6 +5,18 @@ description: Remove extraneous packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-prune.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-prune
+  - /cli-documentation/v7/cli-commands/prune
+  - /cli-documentation/v7/commands/npm-prune
+  - /cli-documentation/v7/commands/prune
+  - /cli-documentation/v7/npm-prune
+  - /cli-documentation/v7/prune
+  - /cli/v7/cli-commands/npm-prune
+  - /cli/v7/cli-commands/prune
+  - /cli/v7/commands/prune
+  - /cli/v7/npm-prune
+  - /cli/v7/prune
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-publish.md
+++ b/content/cli/v7/commands/npm-publish.md
@@ -5,6 +5,18 @@ description: Publish a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-publish.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-publish
+  - /cli-documentation/v7/cli-commands/publish
+  - /cli-documentation/v7/commands/npm-publish
+  - /cli-documentation/v7/commands/publish
+  - /cli-documentation/v7/npm-publish
+  - /cli-documentation/v7/publish
+  - /cli/v7/cli-commands/npm-publish
+  - /cli/v7/cli-commands/publish
+  - /cli/v7/commands/publish
+  - /cli/v7/npm-publish
+  - /cli/v7/publish
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-rebuild.md
+++ b/content/cli/v7/commands/npm-rebuild.md
@@ -5,6 +5,18 @@ description: Rebuild a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-rebuild.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-rebuild
+  - /cli-documentation/v7/cli-commands/rebuild
+  - /cli-documentation/v7/commands/npm-rebuild
+  - /cli-documentation/v7/commands/rebuild
+  - /cli-documentation/v7/npm-rebuild
+  - /cli-documentation/v7/rebuild
+  - /cli/v7/cli-commands/npm-rebuild
+  - /cli/v7/cli-commands/rebuild
+  - /cli/v7/commands/rebuild
+  - /cli/v7/npm-rebuild
+  - /cli/v7/rebuild
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-repo.md
+++ b/content/cli/v7/commands/npm-repo.md
@@ -5,6 +5,18 @@ description: Open package repository page in the browser
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-repo.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-repo
+  - /cli-documentation/v7/cli-commands/repo
+  - /cli-documentation/v7/commands/npm-repo
+  - /cli-documentation/v7/commands/repo
+  - /cli-documentation/v7/npm-repo
+  - /cli-documentation/v7/repo
+  - /cli/v7/cli-commands/npm-repo
+  - /cli/v7/cli-commands/repo
+  - /cli/v7/commands/repo
+  - /cli/v7/npm-repo
+  - /cli/v7/repo
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-restart.md
+++ b/content/cli/v7/commands/npm-restart.md
@@ -5,6 +5,18 @@ description: Restart a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-restart.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-restart
+  - /cli-documentation/v7/cli-commands/restart
+  - /cli-documentation/v7/commands/npm-restart
+  - /cli-documentation/v7/commands/restart
+  - /cli-documentation/v7/npm-restart
+  - /cli-documentation/v7/restart
+  - /cli/v7/cli-commands/npm-restart
+  - /cli/v7/cli-commands/restart
+  - /cli/v7/commands/restart
+  - /cli/v7/npm-restart
+  - /cli/v7/restart
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-root.md
+++ b/content/cli/v7/commands/npm-root.md
@@ -5,6 +5,18 @@ description: Display npm root
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-root.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-root
+  - /cli-documentation/v7/cli-commands/root
+  - /cli-documentation/v7/commands/npm-root
+  - /cli-documentation/v7/commands/root
+  - /cli-documentation/v7/npm-root
+  - /cli-documentation/v7/root
+  - /cli/v7/cli-commands/npm-root
+  - /cli/v7/cli-commands/root
+  - /cli/v7/commands/root
+  - /cli/v7/npm-root
+  - /cli/v7/root
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-run-script.md
+++ b/content/cli/v7/commands/npm-run-script.md
@@ -5,6 +5,18 @@ description: Run arbitrary package scripts
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-run-script.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-run-script
+  - /cli-documentation/v7/cli-commands/run-script
+  - /cli-documentation/v7/commands/npm-run-script
+  - /cli-documentation/v7/commands/run-script
+  - /cli-documentation/v7/npm-run-script
+  - /cli-documentation/v7/run-script
+  - /cli/v7/cli-commands/npm-run-script
+  - /cli/v7/cli-commands/run-script
+  - /cli/v7/commands/run-script
+  - /cli/v7/npm-run-script
+  - /cli/v7/run-script
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-search.md
+++ b/content/cli/v7/commands/npm-search.md
@@ -5,6 +5,18 @@ description: Search for packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-search.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-search
+  - /cli-documentation/v7/cli-commands/search
+  - /cli-documentation/v7/commands/npm-search
+  - /cli-documentation/v7/commands/search
+  - /cli-documentation/v7/npm-search
+  - /cli-documentation/v7/search
+  - /cli/v7/cli-commands/npm-search
+  - /cli/v7/cli-commands/search
+  - /cli/v7/commands/search
+  - /cli/v7/npm-search
+  - /cli/v7/search
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-set-script.md
+++ b/content/cli/v7/commands/npm-set-script.md
@@ -5,6 +5,18 @@ description: Set tasks in the scripts section of package.json
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-set-script.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-set-script
+  - /cli-documentation/v7/cli-commands/set-script
+  - /cli-documentation/v7/commands/npm-set-script
+  - /cli-documentation/v7/commands/set-script
+  - /cli-documentation/v7/npm-set-script
+  - /cli-documentation/v7/set-script
+  - /cli/v7/cli-commands/npm-set-script
+  - /cli/v7/cli-commands/set-script
+  - /cli/v7/commands/set-script
+  - /cli/v7/npm-set-script
+  - /cli/v7/set-script
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-shrinkwrap.md
+++ b/content/cli/v7/commands/npm-shrinkwrap.md
@@ -5,6 +5,18 @@ description: Lock down dependency versions for publication
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-shrinkwrap.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-shrinkwrap
+  - /cli-documentation/v7/cli-commands/shrinkwrap
+  - /cli-documentation/v7/commands/npm-shrinkwrap
+  - /cli-documentation/v7/commands/shrinkwrap
+  - /cli-documentation/v7/npm-shrinkwrap
+  - /cli-documentation/v7/shrinkwrap
+  - /cli/v7/cli-commands/npm-shrinkwrap
+  - /cli/v7/cli-commands/shrinkwrap
+  - /cli/v7/commands/shrinkwrap
+  - /cli/v7/npm-shrinkwrap
+  - /cli/v7/shrinkwrap
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-star.md
+++ b/content/cli/v7/commands/npm-star.md
@@ -5,6 +5,18 @@ description: Mark your favorite packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-star.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-star
+  - /cli-documentation/v7/cli-commands/star
+  - /cli-documentation/v7/commands/npm-star
+  - /cli-documentation/v7/commands/star
+  - /cli-documentation/v7/npm-star
+  - /cli-documentation/v7/star
+  - /cli/v7/cli-commands/npm-star
+  - /cli/v7/cli-commands/star
+  - /cli/v7/commands/star
+  - /cli/v7/npm-star
+  - /cli/v7/star
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-stars.md
+++ b/content/cli/v7/commands/npm-stars.md
@@ -5,6 +5,18 @@ description: View packages marked as favorites
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-stars.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-stars
+  - /cli-documentation/v7/cli-commands/stars
+  - /cli-documentation/v7/commands/npm-stars
+  - /cli-documentation/v7/commands/stars
+  - /cli-documentation/v7/npm-stars
+  - /cli-documentation/v7/stars
+  - /cli/v7/cli-commands/npm-stars
+  - /cli/v7/cli-commands/stars
+  - /cli/v7/commands/stars
+  - /cli/v7/npm-stars
+  - /cli/v7/stars
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-start.md
+++ b/content/cli/v7/commands/npm-start.md
@@ -5,6 +5,18 @@ description: Start a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-start.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-start
+  - /cli-documentation/v7/cli-commands/start
+  - /cli-documentation/v7/commands/npm-start
+  - /cli-documentation/v7/commands/start
+  - /cli-documentation/v7/npm-start
+  - /cli-documentation/v7/start
+  - /cli/v7/cli-commands/npm-start
+  - /cli/v7/cli-commands/start
+  - /cli/v7/commands/start
+  - /cli/v7/npm-start
+  - /cli/v7/start
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-stop.md
+++ b/content/cli/v7/commands/npm-stop.md
@@ -5,6 +5,18 @@ description: Stop a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-stop.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-stop
+  - /cli-documentation/v7/cli-commands/stop
+  - /cli-documentation/v7/commands/npm-stop
+  - /cli-documentation/v7/commands/stop
+  - /cli-documentation/v7/npm-stop
+  - /cli-documentation/v7/stop
+  - /cli/v7/cli-commands/npm-stop
+  - /cli/v7/cli-commands/stop
+  - /cli/v7/commands/stop
+  - /cli/v7/npm-stop
+  - /cli/v7/stop
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-team.md
+++ b/content/cli/v7/commands/npm-team.md
@@ -5,6 +5,18 @@ description: Manage organization teams and team memberships
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-team.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-team
+  - /cli-documentation/v7/cli-commands/team
+  - /cli-documentation/v7/commands/npm-team
+  - /cli-documentation/v7/commands/team
+  - /cli-documentation/v7/npm-team
+  - /cli-documentation/v7/team
+  - /cli/v7/cli-commands/npm-team
+  - /cli/v7/cli-commands/team
+  - /cli/v7/commands/team
+  - /cli/v7/npm-team
+  - /cli/v7/team
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-test.md
+++ b/content/cli/v7/commands/npm-test.md
@@ -5,6 +5,18 @@ description: Test a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-test.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-test
+  - /cli-documentation/v7/cli-commands/test
+  - /cli-documentation/v7/commands/npm-test
+  - /cli-documentation/v7/commands/test
+  - /cli-documentation/v7/npm-test
+  - /cli-documentation/v7/test
+  - /cli/v7/cli-commands/npm-test
+  - /cli/v7/cli-commands/test
+  - /cli/v7/commands/test
+  - /cli/v7/npm-test
+  - /cli/v7/test
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-token.md
+++ b/content/cli/v7/commands/npm-token.md
@@ -5,6 +5,18 @@ description: Manage your authentication tokens
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-token.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-token
+  - /cli-documentation/v7/cli-commands/token
+  - /cli-documentation/v7/commands/npm-token
+  - /cli-documentation/v7/commands/token
+  - /cli-documentation/v7/npm-token
+  - /cli-documentation/v7/token
+  - /cli/v7/cli-commands/npm-token
+  - /cli/v7/cli-commands/token
+  - /cli/v7/commands/token
+  - /cli/v7/npm-token
+  - /cli/v7/token
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-uninstall.md
+++ b/content/cli/v7/commands/npm-uninstall.md
@@ -5,6 +5,18 @@ description: Remove a package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-uninstall.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-uninstall
+  - /cli-documentation/v7/cli-commands/uninstall
+  - /cli-documentation/v7/commands/npm-uninstall
+  - /cli-documentation/v7/commands/uninstall
+  - /cli-documentation/v7/npm-uninstall
+  - /cli-documentation/v7/uninstall
+  - /cli/v7/cli-commands/npm-uninstall
+  - /cli/v7/cli-commands/uninstall
+  - /cli/v7/commands/uninstall
+  - /cli/v7/npm-uninstall
+  - /cli/v7/uninstall
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-unpublish.md
+++ b/content/cli/v7/commands/npm-unpublish.md
@@ -5,6 +5,18 @@ description: Remove a package from the registry
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-unpublish.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-unpublish
+  - /cli-documentation/v7/cli-commands/unpublish
+  - /cli-documentation/v7/commands/npm-unpublish
+  - /cli-documentation/v7/commands/unpublish
+  - /cli-documentation/v7/npm-unpublish
+  - /cli-documentation/v7/unpublish
+  - /cli/v7/cli-commands/npm-unpublish
+  - /cli/v7/cli-commands/unpublish
+  - /cli/v7/commands/unpublish
+  - /cli/v7/npm-unpublish
+  - /cli/v7/unpublish
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-unstar.md
+++ b/content/cli/v7/commands/npm-unstar.md
@@ -5,6 +5,18 @@ description: Remove an item from your favorite packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-unstar.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-unstar
+  - /cli-documentation/v7/cli-commands/unstar
+  - /cli-documentation/v7/commands/npm-unstar
+  - /cli-documentation/v7/commands/unstar
+  - /cli-documentation/v7/npm-unstar
+  - /cli-documentation/v7/unstar
+  - /cli/v7/cli-commands/npm-unstar
+  - /cli/v7/cli-commands/unstar
+  - /cli/v7/commands/unstar
+  - /cli/v7/npm-unstar
+  - /cli/v7/unstar
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-update.md
+++ b/content/cli/v7/commands/npm-update.md
@@ -5,6 +5,18 @@ description: Update packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-update.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-update
+  - /cli-documentation/v7/cli-commands/update
+  - /cli-documentation/v7/commands/npm-update
+  - /cli-documentation/v7/commands/update
+  - /cli-documentation/v7/npm-update
+  - /cli-documentation/v7/update
+  - /cli/v7/cli-commands/npm-update
+  - /cli/v7/cli-commands/update
+  - /cli/v7/commands/update
+  - /cli/v7/npm-update
+  - /cli/v7/update
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-version.md
+++ b/content/cli/v7/commands/npm-version.md
@@ -5,6 +5,18 @@ description: Bump a package version
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-version.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-version
+  - /cli-documentation/v7/cli-commands/version
+  - /cli-documentation/v7/commands/npm-version
+  - /cli-documentation/v7/commands/version
+  - /cli-documentation/v7/npm-version
+  - /cli-documentation/v7/version
+  - /cli/v7/cli-commands/npm-version
+  - /cli/v7/cli-commands/version
+  - /cli/v7/commands/version
+  - /cli/v7/npm-version
+  - /cli/v7/version
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-view.md
+++ b/content/cli/v7/commands/npm-view.md
@@ -5,6 +5,18 @@ description: View registry info
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-view.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-view
+  - /cli-documentation/v7/cli-commands/view
+  - /cli-documentation/v7/commands/npm-view
+  - /cli-documentation/v7/commands/view
+  - /cli-documentation/v7/npm-view
+  - /cli-documentation/v7/view
+  - /cli/v7/cli-commands/npm-view
+  - /cli/v7/cli-commands/view
+  - /cli/v7/commands/view
+  - /cli/v7/npm-view
+  - /cli/v7/view
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm-whoami.md
+++ b/content/cli/v7/commands/npm-whoami.md
@@ -5,6 +5,18 @@ description: Display npm username
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm-whoami.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm-whoami
+  - /cli-documentation/v7/cli-commands/whoami
+  - /cli-documentation/v7/commands/npm-whoami
+  - /cli-documentation/v7/commands/whoami
+  - /cli-documentation/v7/npm-whoami
+  - /cli-documentation/v7/whoami
+  - /cli/v7/cli-commands/npm-whoami
+  - /cli/v7/cli-commands/whoami
+  - /cli/v7/commands/whoami
+  - /cli/v7/npm-whoami
+  - /cli/v7/whoami
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npm.md
+++ b/content/cli/v7/commands/npm.md
@@ -5,6 +5,12 @@ description: javascript package manager
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npm.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npm
+  - /cli-documentation/v7/commands/npm
+  - /cli-documentation/v7/npm
+  - /cli/v7/cli-commands/npm
+  - /cli/v7/npm
 ---
 
 ### Synopsis

--- a/content/cli/v7/commands/npx.md
+++ b/content/cli/v7/commands/npx.md
@@ -5,6 +5,12 @@ description: Run a command from a local or remote npm package
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/commands/npx.md
+redirect_from:
+  - /cli-documentation/v7/cli-commands/npx
+  - /cli-documentation/v7/commands/npx
+  - /cli-documentation/v7/npx
+  - /cli/v7/cli-commands/npx
+  - /cli/v7/npx
 ---
 
 ### Synopsis

--- a/content/cli/v7/configuring-npm/folders.md
+++ b/content/cli/v7/configuring-npm/folders.md
@@ -5,6 +5,10 @@ description: Folder Structures Used by npm
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/configuring-npm/folders.md
+redirect_from:
+  - /cli-documentation/v7/configuring-npm/folders
+  - /cli-documentation/v7/files/folders
+  - /cli/v7/files/folders
 ---
 
 ### Description

--- a/content/cli/v7/configuring-npm/index.mdx
+++ b/content/cli/v7/configuring-npm/index.mdx
@@ -3,6 +3,14 @@ title: Configuring npm
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v7/configuring-npm
+  - /cli-documentation/v7/configuring-npm/index
+  - /cli-documentation/v7/files
+  - /cli-documentation/v7/files/index
+  - /cli/v7/configuring-npm/index
+  - /cli/v7/files
+  - /cli/v7/files/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v7/configuring-npm/install.md
+++ b/content/cli/v7/configuring-npm/install.md
@@ -5,6 +5,10 @@ description: Download and install node and npm
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/configuring-npm/install.md
+redirect_from:
+  - /cli-documentation/v7/configuring-npm/install
+  - /cli-documentation/v7/files/install
+  - /cli/v7/files/install
 ---
 
 ### Description

--- a/content/cli/v7/configuring-npm/npm-shrinkwrap-json.md
+++ b/content/cli/v7/configuring-npm/npm-shrinkwrap-json.md
@@ -5,6 +5,14 @@ description: A publishable lockfile
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/configuring-npm/npm-shrinkwrap-json.md
+redirect_from:
+  - /cli-documentation/v7/configuring-npm/npm-shrinkwrap-json
+  - /cli-documentation/v7/configuring-npm/npm-shrinkwrap.json
+  - /cli-documentation/v7/files/npm-shrinkwrap-json
+  - /cli-documentation/v7/files/npm-shrinkwrap.json
+  - /cli/v7/configuring-npm/npm-shrinkwrap.json
+  - /cli/v7/files/npm-shrinkwrap-json
+  - /cli/v7/files/npm-shrinkwrap.json
 ---
 
 ### Description

--- a/content/cli/v7/configuring-npm/npmrc.md
+++ b/content/cli/v7/configuring-npm/npmrc.md
@@ -5,6 +5,10 @@ description: The npm config files
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/configuring-npm/npmrc.md
+redirect_from:
+  - /cli-documentation/v7/configuring-npm/npmrc
+  - /cli-documentation/v7/files/npmrc
+  - /cli/v7/files/npmrc
 ---
 
 ### Description

--- a/content/cli/v7/configuring-npm/package-json.md
+++ b/content/cli/v7/configuring-npm/package-json.md
@@ -5,6 +5,14 @@ description: Specifics of npm's package.json handling
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/configuring-npm/package-json.md
+redirect_from:
+  - /cli-documentation/v7/configuring-npm/package-json
+  - /cli-documentation/v7/configuring-npm/package.json
+  - /cli-documentation/v7/files/package-json
+  - /cli-documentation/v7/files/package.json
+  - /cli/v7/configuring-npm/package.json
+  - /cli/v7/files/package-json
+  - /cli/v7/files/package.json
 ---
 
 ### Description

--- a/content/cli/v7/configuring-npm/package-lock-json.md
+++ b/content/cli/v7/configuring-npm/package-lock-json.md
@@ -5,6 +5,14 @@ description: A manifestation of the manifest
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/configuring-npm/package-lock-json.md
+redirect_from:
+  - /cli-documentation/v7/configuring-npm/package-lock-json
+  - /cli-documentation/v7/configuring-npm/package-lock.json
+  - /cli-documentation/v7/files/package-lock-json
+  - /cli-documentation/v7/files/package-lock.json
+  - /cli/v7/configuring-npm/package-lock.json
+  - /cli/v7/files/package-lock-json
+  - /cli/v7/files/package-lock.json
 ---
 
 ### Description

--- a/content/cli/v7/index.mdx
+++ b/content/cli/v7/index.mdx
@@ -3,6 +3,10 @@ title: npm CLI
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v7
+  - /cli-documentation/v7/index
+  - /cli/v7/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v7/using-npm/config.md
+++ b/content/cli/v7/using-npm/config.md
@@ -5,6 +5,10 @@ description: More than you probably want to know about npm configuration
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/config.md
+redirect_from:
+  - /cli-documentation/v7/misc/config
+  - /cli-documentation/v7/using-npm/config
+  - /cli/v7/misc/config
 ---
 
 ### Description

--- a/content/cli/v7/using-npm/developers.md
+++ b/content/cli/v7/using-npm/developers.md
@@ -5,6 +5,10 @@ description: Developer Guide
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/developers.md
+redirect_from:
+  - /cli-documentation/v7/misc/developers
+  - /cli-documentation/v7/using-npm/developers
+  - /cli/v7/misc/developers
 ---
 
 ### Description

--- a/content/cli/v7/using-npm/index.mdx
+++ b/content/cli/v7/using-npm/index.mdx
@@ -3,6 +3,14 @@ title: Using npm
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/nav.yml
+redirect_from:
+  - /cli-documentation/v7/misc
+  - /cli-documentation/v7/misc/index
+  - /cli-documentation/v7/using-npm
+  - /cli-documentation/v7/using-npm/index
+  - /cli/v7/misc
+  - /cli/v7/misc/index
+  - /cli/v7/using-npm/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v7/using-npm/orgs.md
+++ b/content/cli/v7/using-npm/orgs.md
@@ -5,6 +5,10 @@ description: Working with Teams & Orgs
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/orgs.md
+redirect_from:
+  - /cli-documentation/v7/misc/orgs
+  - /cli-documentation/v7/using-npm/orgs
+  - /cli/v7/misc/orgs
 ---
 
 ### Description

--- a/content/cli/v7/using-npm/registry.md
+++ b/content/cli/v7/using-npm/registry.md
@@ -5,6 +5,10 @@ description: The JavaScript Package Registry
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/registry.md
+redirect_from:
+  - /cli-documentation/v7/misc/registry
+  - /cli-documentation/v7/using-npm/registry
+  - /cli/v7/misc/registry
 ---
 
 ### Description

--- a/content/cli/v7/using-npm/removal.md
+++ b/content/cli/v7/using-npm/removal.md
@@ -5,6 +5,14 @@ description: Cleaning the Slate
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/removal.md
+redirect_from:
+  - /cli-documentation/v7/misc/removal
+  - /cli-documentation/v7/misc/removing-npm
+  - /cli-documentation/v7/using-npm/removal
+  - /cli-documentation/v7/using-npm/removing-npm
+  - /cli/v7/misc/removal
+  - /cli/v7/misc/removing-npm
+  - /cli/v7/using-npm/removing-npm
 ---
 
 ### Synopsis

--- a/content/cli/v7/using-npm/scope.md
+++ b/content/cli/v7/using-npm/scope.md
@@ -5,6 +5,14 @@ description: Scoped packages
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/scope.md
+redirect_from:
+  - /cli-documentation/v7/misc/npm-scope
+  - /cli-documentation/v7/misc/scope
+  - /cli-documentation/v7/using-npm/npm-scope
+  - /cli-documentation/v7/using-npm/scope
+  - /cli/v7/misc/npm-scope
+  - /cli/v7/misc/scope
+  - /cli/v7/using-npm/npm-scope
 ---
 
 ### Description

--- a/content/cli/v7/using-npm/scripts.md
+++ b/content/cli/v7/using-npm/scripts.md
@@ -5,6 +5,10 @@ description: How npm handles the "scripts" field
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/scripts.md
+redirect_from:
+  - /cli-documentation/v7/misc/scripts
+  - /cli-documentation/v7/using-npm/scripts
+  - /cli/v7/misc/scripts
 ---
 
 ### Description

--- a/content/cli/v7/using-npm/workspaces.md
+++ b/content/cli/v7/using-npm/workspaces.md
@@ -5,6 +5,10 @@ description: Working with workspaces
 github_repo: npm/cli
 github_branch: v7
 github_path: docs/content/using-npm/workspaces.md
+redirect_from:
+  - /cli-documentation/v7/misc/workspaces
+  - /cli-documentation/v7/using-npm/workspaces
+  - /cli/v7/misc/workspaces
 ---
 
 ### Description

--- a/content/cli/v8/commands/index.mdx
+++ b/content/cli/v8/commands/index.mdx
@@ -4,10 +4,26 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/nav.yml
 redirect_from:
+  - /cli-commands
+  - /cli-commands/index
   - /cli-documentation/cli
   - /cli-documentation/cli-commands
+  - /cli-documentation/cli-commands/index
+  - /cli-documentation/commands
+  - /cli-documentation/commands/index
+  - /cli-documentation/v8/cli-commands
+  - /cli-documentation/v8/cli-commands/index
+  - /cli-documentation/v8/commands
+  - /cli-documentation/v8/commands/index
+  - /cli/cli-commands
+  - /cli/cli-commands/index
   - /cli/commands
+  - /cli/commands/index
+  - /cli/v8/cli-commands
+  - /cli/v8/cli-commands/index
+  - /cli/v8/commands/index
   - /commands
+  - /commands/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v8/commands/npm-access.md
+++ b/content/cli/v8/commands/npm-access.md
@@ -7,12 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-access.md
 redirect_from:
   - /cli-commands/access
-  - /cli-commands/access.html
   - /cli-commands/npm-access
   - /cli-documentation/access
+  - /cli-documentation/cli-commands/access
+  - /cli-documentation/cli-commands/npm-access
+  - /cli-documentation/commands/access
+  - /cli-documentation/commands/npm-access
+  - /cli-documentation/npm-access
+  - /cli-documentation/v8/access
+  - /cli-documentation/v8/cli-commands/access
+  - /cli-documentation/v8/cli-commands/npm-access
+  - /cli-documentation/v8/commands/access
+  - /cli-documentation/v8/commands/npm-access
+  - /cli-documentation/v8/npm-access
   - /cli/access
-  - /cli/access.html
+  - /cli/cli-commands/access
+  - /cli/cli-commands/npm-access
   - /cli/commands/access
+  - /cli/commands/npm-access
+  - /cli/npm-access
+  - /cli/v8/access
+  - /cli/v8/cli-commands/access
+  - /cli/v8/cli-commands/npm-access
+  - /cli/v8/commands/access
+  - /cli/v8/npm-access
+  - /commands/access
+  - /commands/npm-access
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-adduser.md
+++ b/content/cli/v8/commands/npm-adduser.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-adduser.md
 redirect_from:
   - /cli-commands/adduser
-  - /cli-commands/adduser.html
   - /cli-commands/npm-adduser
+  - /cli-documentation/adduser
+  - /cli-documentation/cli-commands/adduser
+  - /cli-documentation/cli-commands/npm-adduser
+  - /cli-documentation/commands/adduser
+  - /cli-documentation/commands/npm-adduser
+  - /cli-documentation/npm-adduser
+  - /cli-documentation/v8/adduser
+  - /cli-documentation/v8/cli-commands/adduser
+  - /cli-documentation/v8/cli-commands/npm-adduser
+  - /cli-documentation/v8/commands/adduser
+  - /cli-documentation/v8/commands/npm-adduser
+  - /cli-documentation/v8/npm-adduser
   - /cli/adduser
-  - /cli/adduser.html
+  - /cli/cli-commands/adduser
+  - /cli/cli-commands/npm-adduser
   - /cli/commands/adduser
+  - /cli/commands/npm-adduser
+  - /cli/npm-adduser
+  - /cli/v8/adduser
+  - /cli/v8/cli-commands/adduser
+  - /cli/v8/cli-commands/npm-adduser
+  - /cli/v8/commands/adduser
+  - /cli/v8/npm-adduser
+  - /commands/adduser
+  - /commands/npm-adduser
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-audit.md
+++ b/content/cli/v8/commands/npm-audit.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-audit.md
 redirect_from:
   - /cli-commands/audit
-  - /cli-commands/audit.html
   - /cli-commands/npm-audit
+  - /cli-documentation/audit
+  - /cli-documentation/cli-commands/audit
+  - /cli-documentation/cli-commands/npm-audit
+  - /cli-documentation/commands/audit
+  - /cli-documentation/commands/npm-audit
+  - /cli-documentation/npm-audit
+  - /cli-documentation/v8/audit
+  - /cli-documentation/v8/cli-commands/audit
+  - /cli-documentation/v8/cli-commands/npm-audit
+  - /cli-documentation/v8/commands/audit
+  - /cli-documentation/v8/commands/npm-audit
+  - /cli-documentation/v8/npm-audit
   - /cli/audit
-  - /cli/audit.html
+  - /cli/cli-commands/audit
+  - /cli/cli-commands/npm-audit
   - /cli/commands/audit
+  - /cli/commands/npm-audit
+  - /cli/npm-audit
+  - /cli/v8/audit
+  - /cli/v8/cli-commands/audit
+  - /cli/v8/cli-commands/npm-audit
+  - /cli/v8/commands/audit
+  - /cli/v8/npm-audit
+  - /commands/audit
+  - /commands/npm-audit
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-bin.md
+++ b/content/cli/v8/commands/npm-bin.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-bin.md
 redirect_from:
   - /cli-commands/bin
-  - /cli-commands/bin.html
   - /cli-commands/npm-bin
+  - /cli-documentation/bin
+  - /cli-documentation/cli-commands/bin
+  - /cli-documentation/cli-commands/npm-bin
+  - /cli-documentation/commands/bin
+  - /cli-documentation/commands/npm-bin
+  - /cli-documentation/npm-bin
+  - /cli-documentation/v8/bin
+  - /cli-documentation/v8/cli-commands/bin
+  - /cli-documentation/v8/cli-commands/npm-bin
+  - /cli-documentation/v8/commands/bin
+  - /cli-documentation/v8/commands/npm-bin
+  - /cli-documentation/v8/npm-bin
   - /cli/bin
-  - /cli/bin.html
+  - /cli/cli-commands/bin
+  - /cli/cli-commands/npm-bin
   - /cli/commands/bin
+  - /cli/commands/npm-bin
+  - /cli/npm-bin
+  - /cli/v8/bin
+  - /cli/v8/cli-commands/bin
+  - /cli/v8/cli-commands/npm-bin
+  - /cli/v8/commands/bin
+  - /cli/v8/npm-bin
+  - /commands/bin
+  - /commands/npm-bin
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-bugs.md
+++ b/content/cli/v8/commands/npm-bugs.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-bugs.md
 redirect_from:
   - /cli-commands/bugs
-  - /cli-commands/bugs.html
   - /cli-commands/npm-bugs
+  - /cli-documentation/bugs
+  - /cli-documentation/cli-commands/bugs
+  - /cli-documentation/cli-commands/npm-bugs
+  - /cli-documentation/commands/bugs
+  - /cli-documentation/commands/npm-bugs
+  - /cli-documentation/npm-bugs
+  - /cli-documentation/v8/bugs
+  - /cli-documentation/v8/cli-commands/bugs
+  - /cli-documentation/v8/cli-commands/npm-bugs
+  - /cli-documentation/v8/commands/bugs
+  - /cli-documentation/v8/commands/npm-bugs
+  - /cli-documentation/v8/npm-bugs
   - /cli/bugs
-  - /cli/bugs.html
+  - /cli/cli-commands/bugs
+  - /cli/cli-commands/npm-bugs
   - /cli/commands/bugs
+  - /cli/commands/npm-bugs
+  - /cli/npm-bugs
+  - /cli/v8/bugs
+  - /cli/v8/cli-commands/bugs
+  - /cli/v8/cli-commands/npm-bugs
+  - /cli/v8/commands/bugs
+  - /cli/v8/npm-bugs
+  - /commands/bugs
+  - /commands/npm-bugs
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-cache.md
+++ b/content/cli/v8/commands/npm-cache.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-cache.md
 redirect_from:
   - /cli-commands/cache
-  - /cli-commands/cache.html
   - /cli-commands/npm-cache
+  - /cli-documentation/cache
+  - /cli-documentation/cli-commands/cache
+  - /cli-documentation/cli-commands/npm-cache
+  - /cli-documentation/commands/cache
+  - /cli-documentation/commands/npm-cache
+  - /cli-documentation/npm-cache
+  - /cli-documentation/v8/cache
+  - /cli-documentation/v8/cli-commands/cache
+  - /cli-documentation/v8/cli-commands/npm-cache
+  - /cli-documentation/v8/commands/cache
+  - /cli-documentation/v8/commands/npm-cache
+  - /cli-documentation/v8/npm-cache
   - /cli/cache
-  - /cli/cache.html
+  - /cli/cli-commands/cache
+  - /cli/cli-commands/npm-cache
   - /cli/commands/cache
+  - /cli/commands/npm-cache
+  - /cli/npm-cache
+  - /cli/v8/cache
+  - /cli/v8/cli-commands/cache
+  - /cli/v8/cli-commands/npm-cache
+  - /cli/v8/commands/cache
+  - /cli/v8/npm-cache
+  - /commands/cache
+  - /commands/npm-cache
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-ci.md
+++ b/content/cli/v8/commands/npm-ci.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-ci.md
 redirect_from:
   - /cli-commands/ci
-  - /cli-commands/ci.html
   - /cli-commands/npm-ci
+  - /cli-documentation/ci
+  - /cli-documentation/cli-commands/ci
+  - /cli-documentation/cli-commands/npm-ci
+  - /cli-documentation/commands/ci
+  - /cli-documentation/commands/npm-ci
+  - /cli-documentation/npm-ci
+  - /cli-documentation/v8/ci
+  - /cli-documentation/v8/cli-commands/ci
+  - /cli-documentation/v8/cli-commands/npm-ci
+  - /cli-documentation/v8/commands/ci
+  - /cli-documentation/v8/commands/npm-ci
+  - /cli-documentation/v8/npm-ci
   - /cli/ci
-  - /cli/ci.html
+  - /cli/cli-commands/ci
+  - /cli/cli-commands/npm-ci
   - /cli/commands/ci
+  - /cli/commands/npm-ci
+  - /cli/npm-ci
+  - /cli/v8/ci
+  - /cli/v8/cli-commands/ci
+  - /cli/v8/cli-commands/npm-ci
+  - /cli/v8/commands/ci
+  - /cli/v8/npm-ci
+  - /commands/ci
+  - /commands/npm-ci
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-completion.md
+++ b/content/cli/v8/commands/npm-completion.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-completion.md
 redirect_from:
   - /cli-commands/completion
-  - /cli-commands/completion.html
   - /cli-commands/npm-completion
+  - /cli-documentation/cli-commands/completion
+  - /cli-documentation/cli-commands/npm-completion
+  - /cli-documentation/commands/completion
+  - /cli-documentation/commands/npm-completion
+  - /cli-documentation/completion
+  - /cli-documentation/npm-completion
+  - /cli-documentation/v8/cli-commands/completion
+  - /cli-documentation/v8/cli-commands/npm-completion
+  - /cli-documentation/v8/commands/completion
+  - /cli-documentation/v8/commands/npm-completion
+  - /cli-documentation/v8/completion
+  - /cli-documentation/v8/npm-completion
+  - /cli/cli-commands/completion
+  - /cli/cli-commands/npm-completion
   - /cli/commands/completion
+  - /cli/commands/npm-completion
   - /cli/completion
-  - /cli/completion.html
+  - /cli/npm-completion
+  - /cli/v8/cli-commands/completion
+  - /cli/v8/cli-commands/npm-completion
+  - /cli/v8/commands/completion
+  - /cli/v8/completion
+  - /cli/v8/npm-completion
+  - /commands/completion
+  - /commands/npm-completion
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-config.md
+++ b/content/cli/v8/commands/npm-config.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-config.md
 redirect_from:
   - /cli-commands/config
-  - /cli-commands/config.html
   - /cli-commands/npm-config
+  - /cli-documentation/cli-commands/config
+  - /cli-documentation/cli-commands/npm-config
+  - /cli-documentation/commands/config
+  - /cli-documentation/commands/npm-config
+  - /cli-documentation/config
+  - /cli-documentation/npm-config
+  - /cli-documentation/v8/cli-commands/config
+  - /cli-documentation/v8/cli-commands/npm-config
+  - /cli-documentation/v8/commands/config
+  - /cli-documentation/v8/commands/npm-config
+  - /cli-documentation/v8/config
+  - /cli-documentation/v8/npm-config
+  - /cli/cli-commands/config
+  - /cli/cli-commands/npm-config
   - /cli/commands/config
+  - /cli/commands/npm-config
   - /cli/config
-  - /cli/config.html
+  - /cli/npm-config
+  - /cli/v8/cli-commands/config
+  - /cli/v8/cli-commands/npm-config
+  - /cli/v8/commands/config
+  - /cli/v8/config
+  - /cli/v8/npm-config
+  - /commands/config
+  - /commands/npm-config
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-dedupe.md
+++ b/content/cli/v8/commands/npm-dedupe.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-dedupe.md
 redirect_from:
   - /cli-commands/dedupe
-  - /cli-commands/dedupe.html
   - /cli-commands/npm-dedupe
+  - /cli-documentation/cli-commands/dedupe
+  - /cli-documentation/cli-commands/npm-dedupe
+  - /cli-documentation/commands/dedupe
+  - /cli-documentation/commands/npm-dedupe
+  - /cli-documentation/dedupe
+  - /cli-documentation/npm-dedupe
+  - /cli-documentation/v8/cli-commands/dedupe
+  - /cli-documentation/v8/cli-commands/npm-dedupe
+  - /cli-documentation/v8/commands/dedupe
+  - /cli-documentation/v8/commands/npm-dedupe
+  - /cli-documentation/v8/dedupe
+  - /cli-documentation/v8/npm-dedupe
+  - /cli/cli-commands/dedupe
+  - /cli/cli-commands/npm-dedupe
   - /cli/commands/dedupe
+  - /cli/commands/npm-dedupe
   - /cli/dedupe
-  - /cli/dedupe.html
+  - /cli/npm-dedupe
+  - /cli/v8/cli-commands/dedupe
+  - /cli/v8/cli-commands/npm-dedupe
+  - /cli/v8/commands/dedupe
+  - /cli/v8/dedupe
+  - /cli/v8/npm-dedupe
+  - /commands/dedupe
+  - /commands/npm-dedupe
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-deprecate.md
+++ b/content/cli/v8/commands/npm-deprecate.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-deprecate.md
 redirect_from:
   - /cli-commands/deprecate
-  - /cli-commands/deprecate.html
   - /cli-commands/npm-deprecate
+  - /cli-documentation/cli-commands/deprecate
+  - /cli-documentation/cli-commands/npm-deprecate
+  - /cli-documentation/commands/deprecate
+  - /cli-documentation/commands/npm-deprecate
+  - /cli-documentation/deprecate
+  - /cli-documentation/npm-deprecate
+  - /cli-documentation/v8/cli-commands/deprecate
+  - /cli-documentation/v8/cli-commands/npm-deprecate
+  - /cli-documentation/v8/commands/deprecate
+  - /cli-documentation/v8/commands/npm-deprecate
+  - /cli-documentation/v8/deprecate
+  - /cli-documentation/v8/npm-deprecate
+  - /cli/cli-commands/deprecate
+  - /cli/cli-commands/npm-deprecate
   - /cli/commands/deprecate
+  - /cli/commands/npm-deprecate
   - /cli/deprecate
-  - /cli/deprecate.html
+  - /cli/npm-deprecate
+  - /cli/v8/cli-commands/deprecate
+  - /cli/v8/cli-commands/npm-deprecate
+  - /cli/v8/commands/deprecate
+  - /cli/v8/deprecate
+  - /cli/v8/npm-deprecate
+  - /commands/deprecate
+  - /commands/npm-deprecate
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-diff.md
+++ b/content/cli/v8/commands/npm-diff.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-diff.md
 redirect_from:
   - /cli-commands/diff
-  - /cli-commands/diff.html
   - /cli-commands/npm-diff
+  - /cli-documentation/cli-commands/diff
+  - /cli-documentation/cli-commands/npm-diff
+  - /cli-documentation/commands/diff
+  - /cli-documentation/commands/npm-diff
+  - /cli-documentation/diff
+  - /cli-documentation/npm-diff
+  - /cli-documentation/v8/cli-commands/diff
+  - /cli-documentation/v8/cli-commands/npm-diff
+  - /cli-documentation/v8/commands/diff
+  - /cli-documentation/v8/commands/npm-diff
+  - /cli-documentation/v8/diff
+  - /cli-documentation/v8/npm-diff
+  - /cli/cli-commands/diff
+  - /cli/cli-commands/npm-diff
   - /cli/commands/diff
+  - /cli/commands/npm-diff
   - /cli/diff
-  - /cli/diff.html
+  - /cli/npm-diff
+  - /cli/v8/cli-commands/diff
+  - /cli/v8/cli-commands/npm-diff
+  - /cli/v8/commands/diff
+  - /cli/v8/diff
+  - /cli/v8/npm-diff
+  - /commands/diff
+  - /commands/npm-diff
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-dist-tag.md
+++ b/content/cli/v8/commands/npm-dist-tag.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-dist-tag.md
 redirect_from:
   - /cli-commands/dist-tag
-  - /cli-commands/dist-tag.html
   - /cli-commands/npm-dist-tag
+  - /cli-documentation/cli-commands/dist-tag
+  - /cli-documentation/cli-commands/npm-dist-tag
+  - /cli-documentation/commands/dist-tag
+  - /cli-documentation/commands/npm-dist-tag
+  - /cli-documentation/dist-tag
+  - /cli-documentation/npm-dist-tag
+  - /cli-documentation/v8/cli-commands/dist-tag
+  - /cli-documentation/v8/cli-commands/npm-dist-tag
+  - /cli-documentation/v8/commands/dist-tag
+  - /cli-documentation/v8/commands/npm-dist-tag
+  - /cli-documentation/v8/dist-tag
+  - /cli-documentation/v8/npm-dist-tag
+  - /cli/cli-commands/dist-tag
+  - /cli/cli-commands/npm-dist-tag
   - /cli/commands/dist-tag
+  - /cli/commands/npm-dist-tag
   - /cli/dist-tag
-  - /cli/dist-tag.html
+  - /cli/npm-dist-tag
+  - /cli/v8/cli-commands/dist-tag
+  - /cli/v8/cli-commands/npm-dist-tag
+  - /cli/v8/commands/dist-tag
+  - /cli/v8/dist-tag
+  - /cli/v8/npm-dist-tag
+  - /commands/dist-tag
+  - /commands/npm-dist-tag
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-docs.md
+++ b/content/cli/v8/commands/npm-docs.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-docs.md
 redirect_from:
   - /cli-commands/docs
-  - /cli-commands/docs.html
   - /cli-commands/npm-docs
+  - /cli-documentation/cli-commands/docs
+  - /cli-documentation/cli-commands/npm-docs
+  - /cli-documentation/commands/docs
+  - /cli-documentation/commands/npm-docs
+  - /cli-documentation/docs
+  - /cli-documentation/npm-docs
+  - /cli-documentation/v8/cli-commands/docs
+  - /cli-documentation/v8/cli-commands/npm-docs
+  - /cli-documentation/v8/commands/docs
+  - /cli-documentation/v8/commands/npm-docs
+  - /cli-documentation/v8/docs
+  - /cli-documentation/v8/npm-docs
+  - /cli/cli-commands/docs
+  - /cli/cli-commands/npm-docs
   - /cli/commands/docs
+  - /cli/commands/npm-docs
   - /cli/docs
-  - /cli/docs.html
+  - /cli/npm-docs
+  - /cli/v8/cli-commands/docs
+  - /cli/v8/cli-commands/npm-docs
+  - /cli/v8/commands/docs
+  - /cli/v8/docs
+  - /cli/v8/npm-docs
+  - /commands/docs
+  - /commands/npm-docs
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-doctor.md
+++ b/content/cli/v8/commands/npm-doctor.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-doctor.md
 redirect_from:
   - /cli-commands/doctor
-  - /cli-commands/doctor.html
   - /cli-commands/npm-doctor
+  - /cli-documentation/cli-commands/doctor
+  - /cli-documentation/cli-commands/npm-doctor
+  - /cli-documentation/commands/doctor
+  - /cli-documentation/commands/npm-doctor
+  - /cli-documentation/doctor
+  - /cli-documentation/npm-doctor
+  - /cli-documentation/v8/cli-commands/doctor
+  - /cli-documentation/v8/cli-commands/npm-doctor
+  - /cli-documentation/v8/commands/doctor
+  - /cli-documentation/v8/commands/npm-doctor
+  - /cli-documentation/v8/doctor
+  - /cli-documentation/v8/npm-doctor
+  - /cli/cli-commands/doctor
+  - /cli/cli-commands/npm-doctor
   - /cli/commands/doctor
+  - /cli/commands/npm-doctor
   - /cli/doctor
-  - /cli/doctor.html
+  - /cli/npm-doctor
+  - /cli/v8/cli-commands/doctor
+  - /cli/v8/cli-commands/npm-doctor
+  - /cli/v8/commands/doctor
+  - /cli/v8/doctor
+  - /cli/v8/npm-doctor
+  - /commands/doctor
+  - /commands/npm-doctor
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-edit.md
+++ b/content/cli/v8/commands/npm-edit.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-edit.md
 redirect_from:
   - /cli-commands/edit
-  - /cli-commands/edit.html
   - /cli-commands/npm-edit
+  - /cli-documentation/cli-commands/edit
+  - /cli-documentation/cli-commands/npm-edit
+  - /cli-documentation/commands/edit
+  - /cli-documentation/commands/npm-edit
+  - /cli-documentation/edit
+  - /cli-documentation/npm-edit
+  - /cli-documentation/v8/cli-commands/edit
+  - /cli-documentation/v8/cli-commands/npm-edit
+  - /cli-documentation/v8/commands/edit
+  - /cli-documentation/v8/commands/npm-edit
+  - /cli-documentation/v8/edit
+  - /cli-documentation/v8/npm-edit
+  - /cli/cli-commands/edit
+  - /cli/cli-commands/npm-edit
   - /cli/commands/edit
+  - /cli/commands/npm-edit
   - /cli/edit
-  - /cli/edit.html
+  - /cli/npm-edit
+  - /cli/v8/cli-commands/edit
+  - /cli/v8/cli-commands/npm-edit
+  - /cli/v8/commands/edit
+  - /cli/v8/edit
+  - /cli/v8/npm-edit
+  - /commands/edit
+  - /commands/npm-edit
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-exec.md
+++ b/content/cli/v8/commands/npm-exec.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-exec.md
 redirect_from:
   - /cli-commands/exec
-  - /cli-commands/exec.html
   - /cli-commands/npm-exec
+  - /cli-documentation/cli-commands/exec
+  - /cli-documentation/cli-commands/npm-exec
+  - /cli-documentation/commands/exec
+  - /cli-documentation/commands/npm-exec
+  - /cli-documentation/exec
+  - /cli-documentation/npm-exec
+  - /cli-documentation/v8/cli-commands/exec
+  - /cli-documentation/v8/cli-commands/npm-exec
+  - /cli-documentation/v8/commands/exec
+  - /cli-documentation/v8/commands/npm-exec
+  - /cli-documentation/v8/exec
+  - /cli-documentation/v8/npm-exec
+  - /cli/cli-commands/exec
+  - /cli/cli-commands/npm-exec
   - /cli/commands/exec
+  - /cli/commands/npm-exec
   - /cli/exec
-  - /cli/exec.html
+  - /cli/npm-exec
+  - /cli/v8/cli-commands/exec
+  - /cli/v8/cli-commands/npm-exec
+  - /cli/v8/commands/exec
+  - /cli/v8/exec
+  - /cli/v8/npm-exec
+  - /commands/exec
+  - /commands/npm-exec
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-explain.md
+++ b/content/cli/v8/commands/npm-explain.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-explain.md
 redirect_from:
   - /cli-commands/explain
-  - /cli-commands/explain.html
   - /cli-commands/npm-explain
+  - /cli-documentation/cli-commands/explain
+  - /cli-documentation/cli-commands/npm-explain
+  - /cli-documentation/commands/explain
+  - /cli-documentation/commands/npm-explain
+  - /cli-documentation/explain
+  - /cli-documentation/npm-explain
+  - /cli-documentation/v8/cli-commands/explain
+  - /cli-documentation/v8/cli-commands/npm-explain
+  - /cli-documentation/v8/commands/explain
+  - /cli-documentation/v8/commands/npm-explain
+  - /cli-documentation/v8/explain
+  - /cli-documentation/v8/npm-explain
+  - /cli/cli-commands/explain
+  - /cli/cli-commands/npm-explain
   - /cli/commands/explain
+  - /cli/commands/npm-explain
   - /cli/explain
-  - /cli/explain.html
+  - /cli/npm-explain
+  - /cli/v8/cli-commands/explain
+  - /cli/v8/cli-commands/npm-explain
+  - /cli/v8/commands/explain
+  - /cli/v8/explain
+  - /cli/v8/npm-explain
+  - /commands/explain
+  - /commands/npm-explain
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-explore.md
+++ b/content/cli/v8/commands/npm-explore.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-explore.md
 redirect_from:
   - /cli-commands/explore
-  - /cli-commands/explore.html
   - /cli-commands/npm-explore
+  - /cli-documentation/cli-commands/explore
+  - /cli-documentation/cli-commands/npm-explore
+  - /cli-documentation/commands/explore
+  - /cli-documentation/commands/npm-explore
+  - /cli-documentation/explore
+  - /cli-documentation/npm-explore
+  - /cli-documentation/v8/cli-commands/explore
+  - /cli-documentation/v8/cli-commands/npm-explore
+  - /cli-documentation/v8/commands/explore
+  - /cli-documentation/v8/commands/npm-explore
+  - /cli-documentation/v8/explore
+  - /cli-documentation/v8/npm-explore
+  - /cli/cli-commands/explore
+  - /cli/cli-commands/npm-explore
   - /cli/commands/explore
+  - /cli/commands/npm-explore
   - /cli/explore
-  - /cli/explore.html
+  - /cli/npm-explore
+  - /cli/v8/cli-commands/explore
+  - /cli/v8/cli-commands/npm-explore
+  - /cli/v8/commands/explore
+  - /cli/v8/explore
+  - /cli/v8/npm-explore
+  - /commands/explore
+  - /commands/npm-explore
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-find-dupes.md
+++ b/content/cli/v8/commands/npm-find-dupes.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-find-dupes.md
 redirect_from:
   - /cli-commands/find-dupes
-  - /cli-commands/find-dupes.html
   - /cli-commands/npm-find-dupes
+  - /cli-documentation/cli-commands/find-dupes
+  - /cli-documentation/cli-commands/npm-find-dupes
+  - /cli-documentation/commands/find-dupes
+  - /cli-documentation/commands/npm-find-dupes
+  - /cli-documentation/find-dupes
+  - /cli-documentation/npm-find-dupes
+  - /cli-documentation/v8/cli-commands/find-dupes
+  - /cli-documentation/v8/cli-commands/npm-find-dupes
+  - /cli-documentation/v8/commands/find-dupes
+  - /cli-documentation/v8/commands/npm-find-dupes
+  - /cli-documentation/v8/find-dupes
+  - /cli-documentation/v8/npm-find-dupes
+  - /cli/cli-commands/find-dupes
+  - /cli/cli-commands/npm-find-dupes
   - /cli/commands/find-dupes
+  - /cli/commands/npm-find-dupes
   - /cli/find-dupes
-  - /cli/find-dupes.html
+  - /cli/npm-find-dupes
+  - /cli/v8/cli-commands/find-dupes
+  - /cli/v8/cli-commands/npm-find-dupes
+  - /cli/v8/commands/find-dupes
+  - /cli/v8/find-dupes
+  - /cli/v8/npm-find-dupes
+  - /commands/find-dupes
+  - /commands/npm-find-dupes
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-fund.md
+++ b/content/cli/v8/commands/npm-fund.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-fund.md
 redirect_from:
   - /cli-commands/fund
-  - /cli-commands/fund.html
   - /cli-commands/npm-fund
+  - /cli-documentation/cli-commands/fund
+  - /cli-documentation/cli-commands/npm-fund
+  - /cli-documentation/commands/fund
+  - /cli-documentation/commands/npm-fund
+  - /cli-documentation/fund
+  - /cli-documentation/npm-fund
+  - /cli-documentation/v8/cli-commands/fund
+  - /cli-documentation/v8/cli-commands/npm-fund
+  - /cli-documentation/v8/commands/fund
+  - /cli-documentation/v8/commands/npm-fund
+  - /cli-documentation/v8/fund
+  - /cli-documentation/v8/npm-fund
+  - /cli/cli-commands/fund
+  - /cli/cli-commands/npm-fund
   - /cli/commands/fund
+  - /cli/commands/npm-fund
   - /cli/fund
-  - /cli/fund.html
+  - /cli/npm-fund
+  - /cli/v8/cli-commands/fund
+  - /cli/v8/cli-commands/npm-fund
+  - /cli/v8/commands/fund
+  - /cli/v8/fund
+  - /cli/v8/npm-fund
+  - /commands/fund
+  - /commands/npm-fund
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-help-search.md
+++ b/content/cli/v8/commands/npm-help-search.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-help-search.md
 redirect_from:
   - /cli-commands/help-search
-  - /cli-commands/help-search.html
   - /cli-commands/npm-help-search
+  - /cli-documentation/cli-commands/help-search
+  - /cli-documentation/cli-commands/npm-help-search
+  - /cli-documentation/commands/help-search
+  - /cli-documentation/commands/npm-help-search
+  - /cli-documentation/help-search
+  - /cli-documentation/npm-help-search
+  - /cli-documentation/v8/cli-commands/help-search
+  - /cli-documentation/v8/cli-commands/npm-help-search
+  - /cli-documentation/v8/commands/help-search
+  - /cli-documentation/v8/commands/npm-help-search
+  - /cli-documentation/v8/help-search
+  - /cli-documentation/v8/npm-help-search
+  - /cli/cli-commands/help-search
+  - /cli/cli-commands/npm-help-search
   - /cli/commands/help-search
+  - /cli/commands/npm-help-search
   - /cli/help-search
-  - /cli/help-search.html
+  - /cli/npm-help-search
+  - /cli/v8/cli-commands/help-search
+  - /cli/v8/cli-commands/npm-help-search
+  - /cli/v8/commands/help-search
+  - /cli/v8/help-search
+  - /cli/v8/npm-help-search
+  - /commands/help-search
+  - /commands/npm-help-search
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-help.md
+++ b/content/cli/v8/commands/npm-help.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-help.md
 redirect_from:
   - /cli-commands/help
-  - /cli-commands/help.html
   - /cli-commands/npm-help
+  - /cli-documentation/cli-commands/help
+  - /cli-documentation/cli-commands/npm-help
+  - /cli-documentation/commands/help
+  - /cli-documentation/commands/npm-help
+  - /cli-documentation/help
+  - /cli-documentation/npm-help
+  - /cli-documentation/v8/cli-commands/help
+  - /cli-documentation/v8/cli-commands/npm-help
+  - /cli-documentation/v8/commands/help
+  - /cli-documentation/v8/commands/npm-help
+  - /cli-documentation/v8/help
+  - /cli-documentation/v8/npm-help
+  - /cli/cli-commands/help
+  - /cli/cli-commands/npm-help
   - /cli/commands/help
+  - /cli/commands/npm-help
   - /cli/help
-  - /cli/help.html
+  - /cli/npm-help
+  - /cli/v8/cli-commands/help
+  - /cli/v8/cli-commands/npm-help
+  - /cli/v8/commands/help
+  - /cli/v8/help
+  - /cli/v8/npm-help
+  - /commands/help
+  - /commands/npm-help
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-hook.md
+++ b/content/cli/v8/commands/npm-hook.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-hook.md
 redirect_from:
   - /cli-commands/hook
-  - /cli-commands/hook.html
   - /cli-commands/npm-hook
+  - /cli-documentation/cli-commands/hook
+  - /cli-documentation/cli-commands/npm-hook
+  - /cli-documentation/commands/hook
+  - /cli-documentation/commands/npm-hook
+  - /cli-documentation/hook
+  - /cli-documentation/npm-hook
+  - /cli-documentation/v8/cli-commands/hook
+  - /cli-documentation/v8/cli-commands/npm-hook
+  - /cli-documentation/v8/commands/hook
+  - /cli-documentation/v8/commands/npm-hook
+  - /cli-documentation/v8/hook
+  - /cli-documentation/v8/npm-hook
+  - /cli/cli-commands/hook
+  - /cli/cli-commands/npm-hook
   - /cli/commands/hook
+  - /cli/commands/npm-hook
   - /cli/hook
-  - /cli/hook.html
+  - /cli/npm-hook
+  - /cli/v8/cli-commands/hook
+  - /cli/v8/cli-commands/npm-hook
+  - /cli/v8/commands/hook
+  - /cli/v8/hook
+  - /cli/v8/npm-hook
+  - /commands/hook
+  - /commands/npm-hook
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-init.md
+++ b/content/cli/v8/commands/npm-init.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-init.md
 redirect_from:
   - /cli-commands/init
-  - /cli-commands/init.html
   - /cli-commands/npm-init
+  - /cli-documentation/cli-commands/init
+  - /cli-documentation/cli-commands/npm-init
+  - /cli-documentation/commands/init
+  - /cli-documentation/commands/npm-init
+  - /cli-documentation/init
+  - /cli-documentation/npm-init
+  - /cli-documentation/v8/cli-commands/init
+  - /cli-documentation/v8/cli-commands/npm-init
+  - /cli-documentation/v8/commands/init
+  - /cli-documentation/v8/commands/npm-init
+  - /cli-documentation/v8/init
+  - /cli-documentation/v8/npm-init
+  - /cli/cli-commands/init
+  - /cli/cli-commands/npm-init
   - /cli/commands/init
+  - /cli/commands/npm-init
   - /cli/init
-  - /cli/init.html
+  - /cli/npm-init
+  - /cli/v8/cli-commands/init
+  - /cli/v8/cli-commands/npm-init
+  - /cli/v8/commands/init
+  - /cli/v8/init
+  - /cli/v8/npm-init
+  - /commands/init
+  - /commands/npm-init
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-install-ci-test.md
+++ b/content/cli/v8/commands/npm-install-ci-test.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-install-ci-test.md
 redirect_from:
   - /cli-commands/install-ci-test
-  - /cli-commands/install-ci-test.html
   - /cli-commands/npm-install-ci-test
+  - /cli-documentation/cli-commands/install-ci-test
+  - /cli-documentation/cli-commands/npm-install-ci-test
+  - /cli-documentation/commands/install-ci-test
+  - /cli-documentation/commands/npm-install-ci-test
+  - /cli-documentation/install-ci-test
+  - /cli-documentation/npm-install-ci-test
+  - /cli-documentation/v8/cli-commands/install-ci-test
+  - /cli-documentation/v8/cli-commands/npm-install-ci-test
+  - /cli-documentation/v8/commands/install-ci-test
+  - /cli-documentation/v8/commands/npm-install-ci-test
+  - /cli-documentation/v8/install-ci-test
+  - /cli-documentation/v8/npm-install-ci-test
+  - /cli/cli-commands/install-ci-test
+  - /cli/cli-commands/npm-install-ci-test
   - /cli/commands/install-ci-test
+  - /cli/commands/npm-install-ci-test
   - /cli/install-ci-test
-  - /cli/install-ci-test.html
+  - /cli/npm-install-ci-test
+  - /cli/v8/cli-commands/install-ci-test
+  - /cli/v8/cli-commands/npm-install-ci-test
+  - /cli/v8/commands/install-ci-test
+  - /cli/v8/install-ci-test
+  - /cli/v8/npm-install-ci-test
+  - /commands/install-ci-test
+  - /commands/npm-install-ci-test
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-install-test.md
+++ b/content/cli/v8/commands/npm-install-test.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-install-test.md
 redirect_from:
   - /cli-commands/install-test
-  - /cli-commands/install-test.html
   - /cli-commands/npm-install-test
+  - /cli-documentation/cli-commands/install-test
+  - /cli-documentation/cli-commands/npm-install-test
+  - /cli-documentation/commands/install-test
+  - /cli-documentation/commands/npm-install-test
+  - /cli-documentation/install-test
+  - /cli-documentation/npm-install-test
+  - /cli-documentation/v8/cli-commands/install-test
+  - /cli-documentation/v8/cli-commands/npm-install-test
+  - /cli-documentation/v8/commands/install-test
+  - /cli-documentation/v8/commands/npm-install-test
+  - /cli-documentation/v8/install-test
+  - /cli-documentation/v8/npm-install-test
+  - /cli/cli-commands/install-test
+  - /cli/cli-commands/npm-install-test
   - /cli/commands/install-test
+  - /cli/commands/npm-install-test
   - /cli/install-test
-  - /cli/install-test.html
+  - /cli/npm-install-test
+  - /cli/v8/cli-commands/install-test
+  - /cli/v8/cli-commands/npm-install-test
+  - /cli/v8/commands/install-test
+  - /cli/v8/install-test
+  - /cli/v8/npm-install-test
+  - /commands/install-test
+  - /commands/npm-install-test
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-install.md
+++ b/content/cli/v8/commands/npm-install.md
@@ -7,12 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-install.md
 redirect_from:
   - /cli-commands/install
-  - /cli-commands/install.html
   - /cli-commands/npm-install
+  - /cli-documentation/cli-commands/install
+  - /cli-documentation/cli-commands/npm-install
+  - /cli-documentation/commands/install
+  - /cli-documentation/commands/npm-install
   - /cli-documentation/install
+  - /cli-documentation/npm-install
+  - /cli-documentation/v8/cli-commands/install
+  - /cli-documentation/v8/cli-commands/npm-install
+  - /cli-documentation/v8/commands/install
+  - /cli-documentation/v8/commands/npm-install
+  - /cli-documentation/v8/install
+  - /cli-documentation/v8/npm-install
+  - /cli/cli-commands/install
+  - /cli/cli-commands/npm-install
   - /cli/commands/install
+  - /cli/commands/npm-install
   - /cli/install
-  - /cli/install.html
+  - /cli/npm-install
+  - /cli/v8/cli-commands/install
+  - /cli/v8/cli-commands/npm-install
+  - /cli/v8/commands/install
+  - /cli/v8/install
+  - /cli/v8/npm-install
+  - /commands/install
+  - /commands/npm-install
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-link.md
+++ b/content/cli/v8/commands/npm-link.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-link.md
 redirect_from:
   - /cli-commands/link
-  - /cli-commands/link.html
   - /cli-commands/npm-link
+  - /cli-documentation/cli-commands/link
+  - /cli-documentation/cli-commands/npm-link
+  - /cli-documentation/commands/link
+  - /cli-documentation/commands/npm-link
+  - /cli-documentation/link
+  - /cli-documentation/npm-link
+  - /cli-documentation/v8/cli-commands/link
+  - /cli-documentation/v8/cli-commands/npm-link
+  - /cli-documentation/v8/commands/link
+  - /cli-documentation/v8/commands/npm-link
+  - /cli-documentation/v8/link
+  - /cli-documentation/v8/npm-link
+  - /cli/cli-commands/link
+  - /cli/cli-commands/npm-link
   - /cli/commands/link
+  - /cli/commands/npm-link
   - /cli/link
-  - /cli/link.html
+  - /cli/npm-link
+  - /cli/v8/cli-commands/link
+  - /cli/v8/cli-commands/npm-link
+  - /cli/v8/commands/link
+  - /cli/v8/link
+  - /cli/v8/npm-link
+  - /commands/link
+  - /commands/npm-link
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-logout.md
+++ b/content/cli/v8/commands/npm-logout.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-logout.md
 redirect_from:
   - /cli-commands/logout
-  - /cli-commands/logout.html
   - /cli-commands/npm-logout
+  - /cli-documentation/cli-commands/logout
+  - /cli-documentation/cli-commands/npm-logout
+  - /cli-documentation/commands/logout
+  - /cli-documentation/commands/npm-logout
+  - /cli-documentation/logout
+  - /cli-documentation/npm-logout
+  - /cli-documentation/v8/cli-commands/logout
+  - /cli-documentation/v8/cli-commands/npm-logout
+  - /cli-documentation/v8/commands/logout
+  - /cli-documentation/v8/commands/npm-logout
+  - /cli-documentation/v8/logout
+  - /cli-documentation/v8/npm-logout
+  - /cli/cli-commands/logout
+  - /cli/cli-commands/npm-logout
   - /cli/commands/logout
+  - /cli/commands/npm-logout
   - /cli/logout
-  - /cli/logout.html
+  - /cli/npm-logout
+  - /cli/v8/cli-commands/logout
+  - /cli/v8/cli-commands/npm-logout
+  - /cli/v8/commands/logout
+  - /cli/v8/logout
+  - /cli/v8/npm-logout
+  - /commands/logout
+  - /commands/npm-logout
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-ls.md
+++ b/content/cli/v8/commands/npm-ls.md
@@ -7,11 +7,32 @@ github_branch: v8
 github_path: docs/content/commands/npm-ls.md
 redirect_from:
   - /cli-commands/ls
-  - /cli-commands/ls.html
   - /cli-commands/npm-ls
+  - /cli-documentation/cli-commands/ls
+  - /cli-documentation/cli-commands/npm-ls
+  - /cli-documentation/commands/ls
+  - /cli-documentation/commands/npm-ls
+  - /cli-documentation/ls
+  - /cli-documentation/npm-ls
+  - /cli-documentation/v8/cli-commands/ls
+  - /cli-documentation/v8/cli-commands/npm-ls
+  - /cli-documentation/v8/commands/ls
+  - /cli-documentation/v8/commands/npm-ls
+  - /cli-documentation/v8/ls
+  - /cli-documentation/v8/npm-ls
+  - /cli/cli-commands/ls
+  - /cli/cli-commands/npm-ls
   - /cli/commands/ls
+  - /cli/commands/npm-ls
   - /cli/ls
-  - /cli/ls.html
+  - /cli/npm-ls
+  - /cli/v8/cli-commands/ls
+  - /cli/v8/cli-commands/npm-ls
+  - /cli/v8/commands/ls
+  - /cli/v8/ls
+  - /cli/v8/npm-ls
+  - /commands/ls
+  - /commands/npm-ls
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-org.md
+++ b/content/cli/v8/commands/npm-org.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-org.md
 redirect_from:
   - /cli-commands/npm-org
   - /cli-commands/org
-  - /cli-commands/org.html
+  - /cli-documentation/cli-commands/npm-org
+  - /cli-documentation/cli-commands/org
+  - /cli-documentation/commands/npm-org
+  - /cli-documentation/commands/org
+  - /cli-documentation/npm-org
+  - /cli-documentation/org
+  - /cli-documentation/v8/cli-commands/npm-org
+  - /cli-documentation/v8/cli-commands/org
+  - /cli-documentation/v8/commands/npm-org
+  - /cli-documentation/v8/commands/org
+  - /cli-documentation/v8/npm-org
+  - /cli-documentation/v8/org
+  - /cli/cli-commands/npm-org
+  - /cli/cli-commands/org
+  - /cli/commands/npm-org
   - /cli/commands/org
+  - /cli/npm-org
   - /cli/org
-  - /cli/org.html
+  - /cli/v8/cli-commands/npm-org
+  - /cli/v8/cli-commands/org
+  - /cli/v8/commands/org
+  - /cli/v8/npm-org
+  - /cli/v8/org
+  - /commands/npm-org
+  - /commands/org
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-outdated.md
+++ b/content/cli/v8/commands/npm-outdated.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-outdated.md
 redirect_from:
   - /cli-commands/npm-outdated
   - /cli-commands/outdated
-  - /cli-commands/outdated.html
+  - /cli-documentation/cli-commands/npm-outdated
+  - /cli-documentation/cli-commands/outdated
+  - /cli-documentation/commands/npm-outdated
+  - /cli-documentation/commands/outdated
+  - /cli-documentation/npm-outdated
+  - /cli-documentation/outdated
+  - /cli-documentation/v8/cli-commands/npm-outdated
+  - /cli-documentation/v8/cli-commands/outdated
+  - /cli-documentation/v8/commands/npm-outdated
+  - /cli-documentation/v8/commands/outdated
+  - /cli-documentation/v8/npm-outdated
+  - /cli-documentation/v8/outdated
+  - /cli/cli-commands/npm-outdated
+  - /cli/cli-commands/outdated
+  - /cli/commands/npm-outdated
   - /cli/commands/outdated
+  - /cli/npm-outdated
   - /cli/outdated
-  - /cli/outdated.html
+  - /cli/v8/cli-commands/npm-outdated
+  - /cli/v8/cli-commands/outdated
+  - /cli/v8/commands/outdated
+  - /cli/v8/npm-outdated
+  - /cli/v8/outdated
+  - /commands/npm-outdated
+  - /commands/outdated
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-owner.md
+++ b/content/cli/v8/commands/npm-owner.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-owner.md
 redirect_from:
   - /cli-commands/npm-owner
   - /cli-commands/owner
-  - /cli-commands/owner.html
+  - /cli-documentation/cli-commands/npm-owner
+  - /cli-documentation/cli-commands/owner
+  - /cli-documentation/commands/npm-owner
+  - /cli-documentation/commands/owner
+  - /cli-documentation/npm-owner
+  - /cli-documentation/owner
+  - /cli-documentation/v8/cli-commands/npm-owner
+  - /cli-documentation/v8/cli-commands/owner
+  - /cli-documentation/v8/commands/npm-owner
+  - /cli-documentation/v8/commands/owner
+  - /cli-documentation/v8/npm-owner
+  - /cli-documentation/v8/owner
+  - /cli/cli-commands/npm-owner
+  - /cli/cli-commands/owner
+  - /cli/commands/npm-owner
   - /cli/commands/owner
+  - /cli/npm-owner
   - /cli/owner
-  - /cli/owner.html
+  - /cli/v8/cli-commands/npm-owner
+  - /cli/v8/cli-commands/owner
+  - /cli/v8/commands/owner
+  - /cli/v8/npm-owner
+  - /cli/v8/owner
+  - /commands/npm-owner
+  - /commands/owner
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-pack.md
+++ b/content/cli/v8/commands/npm-pack.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-pack.md
 redirect_from:
   - /cli-commands/npm-pack
   - /cli-commands/pack
-  - /cli-commands/pack.html
+  - /cli-documentation/cli-commands/npm-pack
+  - /cli-documentation/cli-commands/pack
+  - /cli-documentation/commands/npm-pack
+  - /cli-documentation/commands/pack
+  - /cli-documentation/npm-pack
+  - /cli-documentation/pack
+  - /cli-documentation/v8/cli-commands/npm-pack
+  - /cli-documentation/v8/cli-commands/pack
+  - /cli-documentation/v8/commands/npm-pack
+  - /cli-documentation/v8/commands/pack
+  - /cli-documentation/v8/npm-pack
+  - /cli-documentation/v8/pack
+  - /cli/cli-commands/npm-pack
+  - /cli/cli-commands/pack
+  - /cli/commands/npm-pack
   - /cli/commands/pack
+  - /cli/npm-pack
   - /cli/pack
-  - /cli/pack.html
+  - /cli/v8/cli-commands/npm-pack
+  - /cli/v8/cli-commands/pack
+  - /cli/v8/commands/pack
+  - /cli/v8/npm-pack
+  - /cli/v8/pack
+  - /commands/npm-pack
+  - /commands/pack
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-ping.md
+++ b/content/cli/v8/commands/npm-ping.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-ping.md
 redirect_from:
   - /cli-commands/npm-ping
   - /cli-commands/ping
-  - /cli-commands/ping.html
+  - /cli-documentation/cli-commands/npm-ping
+  - /cli-documentation/cli-commands/ping
+  - /cli-documentation/commands/npm-ping
+  - /cli-documentation/commands/ping
+  - /cli-documentation/npm-ping
+  - /cli-documentation/ping
+  - /cli-documentation/v8/cli-commands/npm-ping
+  - /cli-documentation/v8/cli-commands/ping
+  - /cli-documentation/v8/commands/npm-ping
+  - /cli-documentation/v8/commands/ping
+  - /cli-documentation/v8/npm-ping
+  - /cli-documentation/v8/ping
+  - /cli/cli-commands/npm-ping
+  - /cli/cli-commands/ping
+  - /cli/commands/npm-ping
   - /cli/commands/ping
+  - /cli/npm-ping
   - /cli/ping
-  - /cli/ping.html
+  - /cli/v8/cli-commands/npm-ping
+  - /cli/v8/cli-commands/ping
+  - /cli/v8/commands/ping
+  - /cli/v8/npm-ping
+  - /cli/v8/ping
+  - /commands/npm-ping
+  - /commands/ping
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-pkg.md
+++ b/content/cli/v8/commands/npm-pkg.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-pkg.md
 redirect_from:
   - /cli-commands/npm-pkg
   - /cli-commands/pkg
-  - /cli-commands/pkg.html
+  - /cli-documentation/cli-commands/npm-pkg
+  - /cli-documentation/cli-commands/pkg
+  - /cli-documentation/commands/npm-pkg
+  - /cli-documentation/commands/pkg
+  - /cli-documentation/npm-pkg
+  - /cli-documentation/pkg
+  - /cli-documentation/v8/cli-commands/npm-pkg
+  - /cli-documentation/v8/cli-commands/pkg
+  - /cli-documentation/v8/commands/npm-pkg
+  - /cli-documentation/v8/commands/pkg
+  - /cli-documentation/v8/npm-pkg
+  - /cli-documentation/v8/pkg
+  - /cli/cli-commands/npm-pkg
+  - /cli/cli-commands/pkg
+  - /cli/commands/npm-pkg
   - /cli/commands/pkg
+  - /cli/npm-pkg
   - /cli/pkg
-  - /cli/pkg.html
+  - /cli/v8/cli-commands/npm-pkg
+  - /cli/v8/cli-commands/pkg
+  - /cli/v8/commands/pkg
+  - /cli/v8/npm-pkg
+  - /cli/v8/pkg
+  - /commands/npm-pkg
+  - /commands/pkg
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-prefix.md
+++ b/content/cli/v8/commands/npm-prefix.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-prefix.md
 redirect_from:
   - /cli-commands/npm-prefix
   - /cli-commands/prefix
-  - /cli-commands/prefix.html
+  - /cli-documentation/cli-commands/npm-prefix
+  - /cli-documentation/cli-commands/prefix
+  - /cli-documentation/commands/npm-prefix
+  - /cli-documentation/commands/prefix
+  - /cli-documentation/npm-prefix
+  - /cli-documentation/prefix
+  - /cli-documentation/v8/cli-commands/npm-prefix
+  - /cli-documentation/v8/cli-commands/prefix
+  - /cli-documentation/v8/commands/npm-prefix
+  - /cli-documentation/v8/commands/prefix
+  - /cli-documentation/v8/npm-prefix
+  - /cli-documentation/v8/prefix
+  - /cli/cli-commands/npm-prefix
+  - /cli/cli-commands/prefix
+  - /cli/commands/npm-prefix
   - /cli/commands/prefix
+  - /cli/npm-prefix
   - /cli/prefix
-  - /cli/prefix.html
+  - /cli/v8/cli-commands/npm-prefix
+  - /cli/v8/cli-commands/prefix
+  - /cli/v8/commands/prefix
+  - /cli/v8/npm-prefix
+  - /cli/v8/prefix
+  - /commands/npm-prefix
+  - /commands/prefix
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-profile.md
+++ b/content/cli/v8/commands/npm-profile.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-profile.md
 redirect_from:
   - /cli-commands/npm-profile
   - /cli-commands/profile
-  - /cli-commands/profile.html
+  - /cli-documentation/cli-commands/npm-profile
+  - /cli-documentation/cli-commands/profile
+  - /cli-documentation/commands/npm-profile
+  - /cli-documentation/commands/profile
+  - /cli-documentation/npm-profile
+  - /cli-documentation/profile
+  - /cli-documentation/v8/cli-commands/npm-profile
+  - /cli-documentation/v8/cli-commands/profile
+  - /cli-documentation/v8/commands/npm-profile
+  - /cli-documentation/v8/commands/profile
+  - /cli-documentation/v8/npm-profile
+  - /cli-documentation/v8/profile
+  - /cli/cli-commands/npm-profile
+  - /cli/cli-commands/profile
+  - /cli/commands/npm-profile
   - /cli/commands/profile
+  - /cli/npm-profile
   - /cli/profile
-  - /cli/profile.html
+  - /cli/v8/cli-commands/npm-profile
+  - /cli/v8/cli-commands/profile
+  - /cli/v8/commands/profile
+  - /cli/v8/npm-profile
+  - /cli/v8/profile
+  - /commands/npm-profile
+  - /commands/profile
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-prune.md
+++ b/content/cli/v8/commands/npm-prune.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-prune.md
 redirect_from:
   - /cli-commands/npm-prune
   - /cli-commands/prune
-  - /cli-commands/prune.html
+  - /cli-documentation/cli-commands/npm-prune
+  - /cli-documentation/cli-commands/prune
+  - /cli-documentation/commands/npm-prune
+  - /cli-documentation/commands/prune
+  - /cli-documentation/npm-prune
+  - /cli-documentation/prune
+  - /cli-documentation/v8/cli-commands/npm-prune
+  - /cli-documentation/v8/cli-commands/prune
+  - /cli-documentation/v8/commands/npm-prune
+  - /cli-documentation/v8/commands/prune
+  - /cli-documentation/v8/npm-prune
+  - /cli-documentation/v8/prune
+  - /cli/cli-commands/npm-prune
+  - /cli/cli-commands/prune
+  - /cli/commands/npm-prune
   - /cli/commands/prune
+  - /cli/npm-prune
   - /cli/prune
-  - /cli/prune.html
+  - /cli/v8/cli-commands/npm-prune
+  - /cli/v8/cli-commands/prune
+  - /cli/v8/commands/prune
+  - /cli/v8/npm-prune
+  - /cli/v8/prune
+  - /commands/npm-prune
+  - /commands/prune
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-publish.md
+++ b/content/cli/v8/commands/npm-publish.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-publish.md
 redirect_from:
   - /cli-commands/npm-publish
   - /cli-commands/publish
-  - /cli-commands/publish.html
+  - /cli-documentation/cli-commands/npm-publish
+  - /cli-documentation/cli-commands/publish
+  - /cli-documentation/commands/npm-publish
+  - /cli-documentation/commands/publish
+  - /cli-documentation/npm-publish
+  - /cli-documentation/publish
+  - /cli-documentation/v8/cli-commands/npm-publish
+  - /cli-documentation/v8/cli-commands/publish
+  - /cli-documentation/v8/commands/npm-publish
+  - /cli-documentation/v8/commands/publish
+  - /cli-documentation/v8/npm-publish
+  - /cli-documentation/v8/publish
+  - /cli/cli-commands/npm-publish
+  - /cli/cli-commands/publish
+  - /cli/commands/npm-publish
   - /cli/commands/publish
+  - /cli/npm-publish
   - /cli/publish
-  - /cli/publish.html
+  - /cli/v8/cli-commands/npm-publish
+  - /cli/v8/cli-commands/publish
+  - /cli/v8/commands/publish
+  - /cli/v8/npm-publish
+  - /cli/v8/publish
+  - /commands/npm-publish
+  - /commands/publish
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-query.md
+++ b/content/cli/v8/commands/npm-query.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-query.md
 redirect_from:
   - /cli-commands/npm-query
   - /cli-commands/query
-  - /cli-commands/query.html
+  - /cli-documentation/cli-commands/npm-query
+  - /cli-documentation/cli-commands/query
+  - /cli-documentation/commands/npm-query
+  - /cli-documentation/commands/query
+  - /cli-documentation/npm-query
+  - /cli-documentation/query
+  - /cli-documentation/v8/cli-commands/npm-query
+  - /cli-documentation/v8/cli-commands/query
+  - /cli-documentation/v8/commands/npm-query
+  - /cli-documentation/v8/commands/query
+  - /cli-documentation/v8/npm-query
+  - /cli-documentation/v8/query
+  - /cli/cli-commands/npm-query
+  - /cli/cli-commands/query
+  - /cli/commands/npm-query
   - /cli/commands/query
+  - /cli/npm-query
   - /cli/query
-  - /cli/query.html
+  - /cli/v8/cli-commands/npm-query
+  - /cli/v8/cli-commands/query
+  - /cli/v8/commands/query
+  - /cli/v8/npm-query
+  - /cli/v8/query
+  - /commands/npm-query
+  - /commands/query
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-rebuild.md
+++ b/content/cli/v8/commands/npm-rebuild.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-rebuild.md
 redirect_from:
   - /cli-commands/npm-rebuild
   - /cli-commands/rebuild
-  - /cli-commands/rebuild.html
+  - /cli-documentation/cli-commands/npm-rebuild
+  - /cli-documentation/cli-commands/rebuild
+  - /cli-documentation/commands/npm-rebuild
+  - /cli-documentation/commands/rebuild
+  - /cli-documentation/npm-rebuild
+  - /cli-documentation/rebuild
+  - /cli-documentation/v8/cli-commands/npm-rebuild
+  - /cli-documentation/v8/cli-commands/rebuild
+  - /cli-documentation/v8/commands/npm-rebuild
+  - /cli-documentation/v8/commands/rebuild
+  - /cli-documentation/v8/npm-rebuild
+  - /cli-documentation/v8/rebuild
+  - /cli/cli-commands/npm-rebuild
+  - /cli/cli-commands/rebuild
+  - /cli/commands/npm-rebuild
   - /cli/commands/rebuild
+  - /cli/npm-rebuild
   - /cli/rebuild
-  - /cli/rebuild.html
+  - /cli/v8/cli-commands/npm-rebuild
+  - /cli/v8/cli-commands/rebuild
+  - /cli/v8/commands/rebuild
+  - /cli/v8/npm-rebuild
+  - /cli/v8/rebuild
+  - /commands/npm-rebuild
+  - /commands/rebuild
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-repo.md
+++ b/content/cli/v8/commands/npm-repo.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-repo.md
 redirect_from:
   - /cli-commands/npm-repo
   - /cli-commands/repo
-  - /cli-commands/repo.html
+  - /cli-documentation/cli-commands/npm-repo
+  - /cli-documentation/cli-commands/repo
+  - /cli-documentation/commands/npm-repo
+  - /cli-documentation/commands/repo
+  - /cli-documentation/npm-repo
+  - /cli-documentation/repo
+  - /cli-documentation/v8/cli-commands/npm-repo
+  - /cli-documentation/v8/cli-commands/repo
+  - /cli-documentation/v8/commands/npm-repo
+  - /cli-documentation/v8/commands/repo
+  - /cli-documentation/v8/npm-repo
+  - /cli-documentation/v8/repo
+  - /cli/cli-commands/npm-repo
+  - /cli/cli-commands/repo
+  - /cli/commands/npm-repo
   - /cli/commands/repo
+  - /cli/npm-repo
   - /cli/repo
-  - /cli/repo.html
+  - /cli/v8/cli-commands/npm-repo
+  - /cli/v8/cli-commands/repo
+  - /cli/v8/commands/repo
+  - /cli/v8/npm-repo
+  - /cli/v8/repo
+  - /commands/npm-repo
+  - /commands/repo
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-restart.md
+++ b/content/cli/v8/commands/npm-restart.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-restart.md
 redirect_from:
   - /cli-commands/npm-restart
   - /cli-commands/restart
-  - /cli-commands/restart.html
+  - /cli-documentation/cli-commands/npm-restart
+  - /cli-documentation/cli-commands/restart
+  - /cli-documentation/commands/npm-restart
+  - /cli-documentation/commands/restart
+  - /cli-documentation/npm-restart
+  - /cli-documentation/restart
+  - /cli-documentation/v8/cli-commands/npm-restart
+  - /cli-documentation/v8/cli-commands/restart
+  - /cli-documentation/v8/commands/npm-restart
+  - /cli-documentation/v8/commands/restart
+  - /cli-documentation/v8/npm-restart
+  - /cli-documentation/v8/restart
+  - /cli/cli-commands/npm-restart
+  - /cli/cli-commands/restart
+  - /cli/commands/npm-restart
   - /cli/commands/restart
+  - /cli/npm-restart
   - /cli/restart
-  - /cli/restart.html
+  - /cli/v8/cli-commands/npm-restart
+  - /cli/v8/cli-commands/restart
+  - /cli/v8/commands/restart
+  - /cli/v8/npm-restart
+  - /cli/v8/restart
+  - /commands/npm-restart
+  - /commands/restart
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-root.md
+++ b/content/cli/v8/commands/npm-root.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-root.md
 redirect_from:
   - /cli-commands/npm-root
   - /cli-commands/root
-  - /cli-commands/root.html
+  - /cli-documentation/cli-commands/npm-root
+  - /cli-documentation/cli-commands/root
+  - /cli-documentation/commands/npm-root
+  - /cli-documentation/commands/root
+  - /cli-documentation/npm-root
+  - /cli-documentation/root
+  - /cli-documentation/v8/cli-commands/npm-root
+  - /cli-documentation/v8/cli-commands/root
+  - /cli-documentation/v8/commands/npm-root
+  - /cli-documentation/v8/commands/root
+  - /cli-documentation/v8/npm-root
+  - /cli-documentation/v8/root
+  - /cli/cli-commands/npm-root
+  - /cli/cli-commands/root
+  - /cli/commands/npm-root
   - /cli/commands/root
+  - /cli/npm-root
   - /cli/root
-  - /cli/root.html
+  - /cli/v8/cli-commands/npm-root
+  - /cli/v8/cli-commands/root
+  - /cli/v8/commands/root
+  - /cli/v8/npm-root
+  - /cli/v8/root
+  - /commands/npm-root
+  - /commands/root
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-run-script.md
+++ b/content/cli/v8/commands/npm-run-script.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-run-script.md
 redirect_from:
   - /cli-commands/npm-run-script
   - /cli-commands/run-script
-  - /cli-commands/run-script.html
+  - /cli-documentation/cli-commands/npm-run-script
+  - /cli-documentation/cli-commands/run-script
+  - /cli-documentation/commands/npm-run-script
+  - /cli-documentation/commands/run-script
+  - /cli-documentation/npm-run-script
+  - /cli-documentation/run-script
+  - /cli-documentation/v8/cli-commands/npm-run-script
+  - /cli-documentation/v8/cli-commands/run-script
+  - /cli-documentation/v8/commands/npm-run-script
+  - /cli-documentation/v8/commands/run-script
+  - /cli-documentation/v8/npm-run-script
+  - /cli-documentation/v8/run-script
+  - /cli/cli-commands/npm-run-script
+  - /cli/cli-commands/run-script
+  - /cli/commands/npm-run-script
   - /cli/commands/run-script
+  - /cli/npm-run-script
   - /cli/run-script
-  - /cli/run-script.html
+  - /cli/v8/cli-commands/npm-run-script
+  - /cli/v8/cli-commands/run-script
+  - /cli/v8/commands/run-script
+  - /cli/v8/npm-run-script
+  - /cli/v8/run-script
+  - /commands/npm-run-script
+  - /commands/run-script
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-search.md
+++ b/content/cli/v8/commands/npm-search.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-search.md
 redirect_from:
   - /cli-commands/npm-search
   - /cli-commands/search
-  - /cli-commands/search.html
+  - /cli-documentation/cli-commands/npm-search
+  - /cli-documentation/cli-commands/search
+  - /cli-documentation/commands/npm-search
+  - /cli-documentation/commands/search
+  - /cli-documentation/npm-search
+  - /cli-documentation/search
+  - /cli-documentation/v8/cli-commands/npm-search
+  - /cli-documentation/v8/cli-commands/search
+  - /cli-documentation/v8/commands/npm-search
+  - /cli-documentation/v8/commands/search
+  - /cli-documentation/v8/npm-search
+  - /cli-documentation/v8/search
+  - /cli/cli-commands/npm-search
+  - /cli/cli-commands/search
+  - /cli/commands/npm-search
   - /cli/commands/search
+  - /cli/npm-search
   - /cli/search
-  - /cli/search.html
+  - /cli/v8/cli-commands/npm-search
+  - /cli/v8/cli-commands/search
+  - /cli/v8/commands/search
+  - /cli/v8/npm-search
+  - /cli/v8/search
+  - /commands/npm-search
+  - /commands/search
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-set-script.md
+++ b/content/cli/v8/commands/npm-set-script.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-set-script.md
 redirect_from:
   - /cli-commands/npm-set-script
   - /cli-commands/set-script
-  - /cli-commands/set-script.html
+  - /cli-documentation/cli-commands/npm-set-script
+  - /cli-documentation/cli-commands/set-script
+  - /cli-documentation/commands/npm-set-script
+  - /cli-documentation/commands/set-script
+  - /cli-documentation/npm-set-script
+  - /cli-documentation/set-script
+  - /cli-documentation/v8/cli-commands/npm-set-script
+  - /cli-documentation/v8/cli-commands/set-script
+  - /cli-documentation/v8/commands/npm-set-script
+  - /cli-documentation/v8/commands/set-script
+  - /cli-documentation/v8/npm-set-script
+  - /cli-documentation/v8/set-script
+  - /cli/cli-commands/npm-set-script
+  - /cli/cli-commands/set-script
+  - /cli/commands/npm-set-script
   - /cli/commands/set-script
+  - /cli/npm-set-script
   - /cli/set-script
-  - /cli/set-script.html
+  - /cli/v8/cli-commands/npm-set-script
+  - /cli/v8/cli-commands/set-script
+  - /cli/v8/commands/set-script
+  - /cli/v8/npm-set-script
+  - /cli/v8/set-script
+  - /commands/npm-set-script
+  - /commands/set-script
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-shrinkwrap.md
+++ b/content/cli/v8/commands/npm-shrinkwrap.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-shrinkwrap.md
 redirect_from:
   - /cli-commands/npm-shrinkwrap
   - /cli-commands/shrinkwrap
-  - /cli-commands/shrinkwrap.html
+  - /cli-documentation/cli-commands/npm-shrinkwrap
+  - /cli-documentation/cli-commands/shrinkwrap
+  - /cli-documentation/commands/npm-shrinkwrap
+  - /cli-documentation/commands/shrinkwrap
+  - /cli-documentation/npm-shrinkwrap
+  - /cli-documentation/shrinkwrap
+  - /cli-documentation/v8/cli-commands/npm-shrinkwrap
+  - /cli-documentation/v8/cli-commands/shrinkwrap
+  - /cli-documentation/v8/commands/npm-shrinkwrap
+  - /cli-documentation/v8/commands/shrinkwrap
+  - /cli-documentation/v8/npm-shrinkwrap
+  - /cli-documentation/v8/shrinkwrap
+  - /cli/cli-commands/npm-shrinkwrap
+  - /cli/cli-commands/shrinkwrap
+  - /cli/commands/npm-shrinkwrap
   - /cli/commands/shrinkwrap
+  - /cli/npm-shrinkwrap
   - /cli/shrinkwrap
-  - /cli/shrinkwrap.html
+  - /cli/v8/cli-commands/npm-shrinkwrap
+  - /cli/v8/cli-commands/shrinkwrap
+  - /cli/v8/commands/shrinkwrap
+  - /cli/v8/npm-shrinkwrap
+  - /cli/v8/shrinkwrap
+  - /commands/npm-shrinkwrap
+  - /commands/shrinkwrap
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-star.md
+++ b/content/cli/v8/commands/npm-star.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-star.md
 redirect_from:
   - /cli-commands/npm-star
   - /cli-commands/star
-  - /cli-commands/star.html
+  - /cli-documentation/cli-commands/npm-star
+  - /cli-documentation/cli-commands/star
+  - /cli-documentation/commands/npm-star
+  - /cli-documentation/commands/star
+  - /cli-documentation/npm-star
+  - /cli-documentation/star
+  - /cli-documentation/v8/cli-commands/npm-star
+  - /cli-documentation/v8/cli-commands/star
+  - /cli-documentation/v8/commands/npm-star
+  - /cli-documentation/v8/commands/star
+  - /cli-documentation/v8/npm-star
+  - /cli-documentation/v8/star
+  - /cli/cli-commands/npm-star
+  - /cli/cli-commands/star
+  - /cli/commands/npm-star
   - /cli/commands/star
+  - /cli/npm-star
   - /cli/star
-  - /cli/star.html
+  - /cli/v8/cli-commands/npm-star
+  - /cli/v8/cli-commands/star
+  - /cli/v8/commands/star
+  - /cli/v8/npm-star
+  - /cli/v8/star
+  - /commands/npm-star
+  - /commands/star
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-stars.md
+++ b/content/cli/v8/commands/npm-stars.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-stars.md
 redirect_from:
   - /cli-commands/npm-stars
   - /cli-commands/stars
-  - /cli-commands/stars.html
+  - /cli-documentation/cli-commands/npm-stars
+  - /cli-documentation/cli-commands/stars
+  - /cli-documentation/commands/npm-stars
+  - /cli-documentation/commands/stars
+  - /cli-documentation/npm-stars
+  - /cli-documentation/stars
+  - /cli-documentation/v8/cli-commands/npm-stars
+  - /cli-documentation/v8/cli-commands/stars
+  - /cli-documentation/v8/commands/npm-stars
+  - /cli-documentation/v8/commands/stars
+  - /cli-documentation/v8/npm-stars
+  - /cli-documentation/v8/stars
+  - /cli/cli-commands/npm-stars
+  - /cli/cli-commands/stars
+  - /cli/commands/npm-stars
   - /cli/commands/stars
+  - /cli/npm-stars
   - /cli/stars
-  - /cli/stars.html
+  - /cli/v8/cli-commands/npm-stars
+  - /cli/v8/cli-commands/stars
+  - /cli/v8/commands/stars
+  - /cli/v8/npm-stars
+  - /cli/v8/stars
+  - /commands/npm-stars
+  - /commands/stars
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-start.md
+++ b/content/cli/v8/commands/npm-start.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-start.md
 redirect_from:
   - /cli-commands/npm-start
   - /cli-commands/start
-  - /cli-commands/start.html
+  - /cli-documentation/cli-commands/npm-start
+  - /cli-documentation/cli-commands/start
+  - /cli-documentation/commands/npm-start
+  - /cli-documentation/commands/start
+  - /cli-documentation/npm-start
+  - /cli-documentation/start
+  - /cli-documentation/v8/cli-commands/npm-start
+  - /cli-documentation/v8/cli-commands/start
+  - /cli-documentation/v8/commands/npm-start
+  - /cli-documentation/v8/commands/start
+  - /cli-documentation/v8/npm-start
+  - /cli-documentation/v8/start
+  - /cli/cli-commands/npm-start
+  - /cli/cli-commands/start
+  - /cli/commands/npm-start
   - /cli/commands/start
+  - /cli/npm-start
   - /cli/start
-  - /cli/start.html
+  - /cli/v8/cli-commands/npm-start
+  - /cli/v8/cli-commands/start
+  - /cli/v8/commands/start
+  - /cli/v8/npm-start
+  - /cli/v8/start
+  - /commands/npm-start
+  - /commands/start
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-stop.md
+++ b/content/cli/v8/commands/npm-stop.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-stop.md
 redirect_from:
   - /cli-commands/npm-stop
   - /cli-commands/stop
-  - /cli-commands/stop.html
+  - /cli-documentation/cli-commands/npm-stop
+  - /cli-documentation/cli-commands/stop
+  - /cli-documentation/commands/npm-stop
+  - /cli-documentation/commands/stop
+  - /cli-documentation/npm-stop
+  - /cli-documentation/stop
+  - /cli-documentation/v8/cli-commands/npm-stop
+  - /cli-documentation/v8/cli-commands/stop
+  - /cli-documentation/v8/commands/npm-stop
+  - /cli-documentation/v8/commands/stop
+  - /cli-documentation/v8/npm-stop
+  - /cli-documentation/v8/stop
+  - /cli/cli-commands/npm-stop
+  - /cli/cli-commands/stop
+  - /cli/commands/npm-stop
   - /cli/commands/stop
+  - /cli/npm-stop
   - /cli/stop
-  - /cli/stop.html
+  - /cli/v8/cli-commands/npm-stop
+  - /cli/v8/cli-commands/stop
+  - /cli/v8/commands/stop
+  - /cli/v8/npm-stop
+  - /cli/v8/stop
+  - /commands/npm-stop
+  - /commands/stop
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-team.md
+++ b/content/cli/v8/commands/npm-team.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-team.md
 redirect_from:
   - /cli-commands/npm-team
   - /cli-commands/team
-  - /cli-commands/team.html
+  - /cli-documentation/cli-commands/npm-team
+  - /cli-documentation/cli-commands/team
+  - /cli-documentation/commands/npm-team
+  - /cli-documentation/commands/team
+  - /cli-documentation/npm-team
+  - /cli-documentation/team
+  - /cli-documentation/v8/cli-commands/npm-team
+  - /cli-documentation/v8/cli-commands/team
+  - /cli-documentation/v8/commands/npm-team
+  - /cli-documentation/v8/commands/team
+  - /cli-documentation/v8/npm-team
+  - /cli-documentation/v8/team
+  - /cli/cli-commands/npm-team
+  - /cli/cli-commands/team
+  - /cli/commands/npm-team
   - /cli/commands/team
+  - /cli/npm-team
   - /cli/team
-  - /cli/team.html
+  - /cli/v8/cli-commands/npm-team
+  - /cli/v8/cli-commands/team
+  - /cli/v8/commands/team
+  - /cli/v8/npm-team
+  - /cli/v8/team
+  - /commands/npm-team
+  - /commands/team
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-test.md
+++ b/content/cli/v8/commands/npm-test.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-test.md
 redirect_from:
   - /cli-commands/npm-test
   - /cli-commands/test
-  - /cli-commands/test.html
+  - /cli-documentation/cli-commands/npm-test
+  - /cli-documentation/cli-commands/test
+  - /cli-documentation/commands/npm-test
+  - /cli-documentation/commands/test
+  - /cli-documentation/npm-test
+  - /cli-documentation/test
+  - /cli-documentation/v8/cli-commands/npm-test
+  - /cli-documentation/v8/cli-commands/test
+  - /cli-documentation/v8/commands/npm-test
+  - /cli-documentation/v8/commands/test
+  - /cli-documentation/v8/npm-test
+  - /cli-documentation/v8/test
+  - /cli/cli-commands/npm-test
+  - /cli/cli-commands/test
+  - /cli/commands/npm-test
   - /cli/commands/test
+  - /cli/npm-test
   - /cli/test
-  - /cli/test.html
+  - /cli/v8/cli-commands/npm-test
+  - /cli/v8/cli-commands/test
+  - /cli/v8/commands/test
+  - /cli/v8/npm-test
+  - /cli/v8/test
+  - /commands/npm-test
+  - /commands/test
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-token.md
+++ b/content/cli/v8/commands/npm-token.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-token.md
 redirect_from:
   - /cli-commands/npm-token
   - /cli-commands/token
-  - /cli-commands/token.html
+  - /cli-documentation/cli-commands/npm-token
+  - /cli-documentation/cli-commands/token
+  - /cli-documentation/commands/npm-token
+  - /cli-documentation/commands/token
+  - /cli-documentation/npm-token
+  - /cli-documentation/token
+  - /cli-documentation/v8/cli-commands/npm-token
+  - /cli-documentation/v8/cli-commands/token
+  - /cli-documentation/v8/commands/npm-token
+  - /cli-documentation/v8/commands/token
+  - /cli-documentation/v8/npm-token
+  - /cli-documentation/v8/token
+  - /cli/cli-commands/npm-token
+  - /cli/cli-commands/token
+  - /cli/commands/npm-token
   - /cli/commands/token
+  - /cli/npm-token
   - /cli/token
-  - /cli/token.html
+  - /cli/v8/cli-commands/npm-token
+  - /cli/v8/cli-commands/token
+  - /cli/v8/commands/token
+  - /cli/v8/npm-token
+  - /cli/v8/token
+  - /commands/npm-token
+  - /commands/token
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-uninstall.md
+++ b/content/cli/v8/commands/npm-uninstall.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-uninstall.md
 redirect_from:
   - /cli-commands/npm-uninstall
   - /cli-commands/uninstall
-  - /cli-commands/uninstall.html
+  - /cli-documentation/cli-commands/npm-uninstall
+  - /cli-documentation/cli-commands/uninstall
+  - /cli-documentation/commands/npm-uninstall
+  - /cli-documentation/commands/uninstall
+  - /cli-documentation/npm-uninstall
+  - /cli-documentation/uninstall
+  - /cli-documentation/v8/cli-commands/npm-uninstall
+  - /cli-documentation/v8/cli-commands/uninstall
+  - /cli-documentation/v8/commands/npm-uninstall
+  - /cli-documentation/v8/commands/uninstall
+  - /cli-documentation/v8/npm-uninstall
+  - /cli-documentation/v8/uninstall
+  - /cli/cli-commands/npm-uninstall
+  - /cli/cli-commands/uninstall
+  - /cli/commands/npm-uninstall
   - /cli/commands/uninstall
+  - /cli/npm-uninstall
   - /cli/uninstall
-  - /cli/uninstall.html
+  - /cli/v8/cli-commands/npm-uninstall
+  - /cli/v8/cli-commands/uninstall
+  - /cli/v8/commands/uninstall
+  - /cli/v8/npm-uninstall
+  - /cli/v8/uninstall
+  - /commands/npm-uninstall
+  - /commands/uninstall
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-unpublish.md
+++ b/content/cli/v8/commands/npm-unpublish.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-unpublish.md
 redirect_from:
   - /cli-commands/npm-unpublish
   - /cli-commands/unpublish
-  - /cli-commands/unpublish.html
+  - /cli-documentation/cli-commands/npm-unpublish
+  - /cli-documentation/cli-commands/unpublish
+  - /cli-documentation/commands/npm-unpublish
+  - /cli-documentation/commands/unpublish
+  - /cli-documentation/npm-unpublish
+  - /cli-documentation/unpublish
+  - /cli-documentation/v8/cli-commands/npm-unpublish
+  - /cli-documentation/v8/cli-commands/unpublish
+  - /cli-documentation/v8/commands/npm-unpublish
+  - /cli-documentation/v8/commands/unpublish
+  - /cli-documentation/v8/npm-unpublish
+  - /cli-documentation/v8/unpublish
+  - /cli/cli-commands/npm-unpublish
+  - /cli/cli-commands/unpublish
+  - /cli/commands/npm-unpublish
   - /cli/commands/unpublish
+  - /cli/npm-unpublish
   - /cli/unpublish
-  - /cli/unpublish.html
+  - /cli/v8/cli-commands/npm-unpublish
+  - /cli/v8/cli-commands/unpublish
+  - /cli/v8/commands/unpublish
+  - /cli/v8/npm-unpublish
+  - /cli/v8/unpublish
+  - /commands/npm-unpublish
+  - /commands/unpublish
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-unstar.md
+++ b/content/cli/v8/commands/npm-unstar.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-unstar.md
 redirect_from:
   - /cli-commands/npm-unstar
   - /cli-commands/unstar
-  - /cli-commands/unstar.html
+  - /cli-documentation/cli-commands/npm-unstar
+  - /cli-documentation/cli-commands/unstar
+  - /cli-documentation/commands/npm-unstar
+  - /cli-documentation/commands/unstar
+  - /cli-documentation/npm-unstar
+  - /cli-documentation/unstar
+  - /cli-documentation/v8/cli-commands/npm-unstar
+  - /cli-documentation/v8/cli-commands/unstar
+  - /cli-documentation/v8/commands/npm-unstar
+  - /cli-documentation/v8/commands/unstar
+  - /cli-documentation/v8/npm-unstar
+  - /cli-documentation/v8/unstar
+  - /cli/cli-commands/npm-unstar
+  - /cli/cli-commands/unstar
+  - /cli/commands/npm-unstar
   - /cli/commands/unstar
+  - /cli/npm-unstar
   - /cli/unstar
-  - /cli/unstar.html
+  - /cli/v8/cli-commands/npm-unstar
+  - /cli/v8/cli-commands/unstar
+  - /cli/v8/commands/unstar
+  - /cli/v8/npm-unstar
+  - /cli/v8/unstar
+  - /commands/npm-unstar
+  - /commands/unstar
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-update.md
+++ b/content/cli/v8/commands/npm-update.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-update.md
 redirect_from:
   - /cli-commands/npm-update
   - /cli-commands/update
-  - /cli-commands/update.html
+  - /cli-documentation/cli-commands/npm-update
+  - /cli-documentation/cli-commands/update
+  - /cli-documentation/commands/npm-update
+  - /cli-documentation/commands/update
+  - /cli-documentation/npm-update
+  - /cli-documentation/update
+  - /cli-documentation/v8/cli-commands/npm-update
+  - /cli-documentation/v8/cli-commands/update
+  - /cli-documentation/v8/commands/npm-update
+  - /cli-documentation/v8/commands/update
+  - /cli-documentation/v8/npm-update
+  - /cli-documentation/v8/update
+  - /cli/cli-commands/npm-update
+  - /cli/cli-commands/update
+  - /cli/commands/npm-update
   - /cli/commands/update
+  - /cli/npm-update
   - /cli/update
-  - /cli/update.html
+  - /cli/v8/cli-commands/npm-update
+  - /cli/v8/cli-commands/update
+  - /cli/v8/commands/update
+  - /cli/v8/npm-update
+  - /cli/v8/update
+  - /commands/npm-update
+  - /commands/update
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-version.md
+++ b/content/cli/v8/commands/npm-version.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-version.md
 redirect_from:
   - /cli-commands/npm-version
   - /cli-commands/version
-  - /cli-commands/version.html
+  - /cli-documentation/cli-commands/npm-version
+  - /cli-documentation/cli-commands/version
+  - /cli-documentation/commands/npm-version
+  - /cli-documentation/commands/version
+  - /cli-documentation/npm-version
+  - /cli-documentation/v8/cli-commands/npm-version
+  - /cli-documentation/v8/cli-commands/version
+  - /cli-documentation/v8/commands/npm-version
+  - /cli-documentation/v8/commands/version
+  - /cli-documentation/v8/npm-version
+  - /cli-documentation/v8/version
+  - /cli-documentation/version
+  - /cli/cli-commands/npm-version
+  - /cli/cli-commands/version
+  - /cli/commands/npm-version
   - /cli/commands/version
+  - /cli/npm-version
+  - /cli/v8/cli-commands/npm-version
+  - /cli/v8/cli-commands/version
+  - /cli/v8/commands/version
+  - /cli/v8/npm-version
+  - /cli/v8/version
   - /cli/version
-  - /cli/version.html
+  - /commands/npm-version
+  - /commands/version
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-view.md
+++ b/content/cli/v8/commands/npm-view.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-view.md
 redirect_from:
   - /cli-commands/npm-view
   - /cli-commands/view
-  - /cli-commands/view.html
+  - /cli-documentation/cli-commands/npm-view
+  - /cli-documentation/cli-commands/view
+  - /cli-documentation/commands/npm-view
+  - /cli-documentation/commands/view
+  - /cli-documentation/npm-view
+  - /cli-documentation/v8/cli-commands/npm-view
+  - /cli-documentation/v8/cli-commands/view
+  - /cli-documentation/v8/commands/npm-view
+  - /cli-documentation/v8/commands/view
+  - /cli-documentation/v8/npm-view
+  - /cli-documentation/v8/view
+  - /cli-documentation/view
+  - /cli/cli-commands/npm-view
+  - /cli/cli-commands/view
+  - /cli/commands/npm-view
   - /cli/commands/view
+  - /cli/npm-view
+  - /cli/v8/cli-commands/npm-view
+  - /cli/v8/cli-commands/view
+  - /cli/v8/commands/view
+  - /cli/v8/npm-view
+  - /cli/v8/view
   - /cli/view
-  - /cli/view.html
+  - /commands/npm-view
+  - /commands/view
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm-whoami.md
+++ b/content/cli/v8/commands/npm-whoami.md
@@ -8,10 +8,31 @@ github_path: docs/content/commands/npm-whoami.md
 redirect_from:
   - /cli-commands/npm-whoami
   - /cli-commands/whoami
-  - /cli-commands/whoami.html
+  - /cli-documentation/cli-commands/npm-whoami
+  - /cli-documentation/cli-commands/whoami
+  - /cli-documentation/commands/npm-whoami
+  - /cli-documentation/commands/whoami
+  - /cli-documentation/npm-whoami
+  - /cli-documentation/v8/cli-commands/npm-whoami
+  - /cli-documentation/v8/cli-commands/whoami
+  - /cli-documentation/v8/commands/npm-whoami
+  - /cli-documentation/v8/commands/whoami
+  - /cli-documentation/v8/npm-whoami
+  - /cli-documentation/v8/whoami
+  - /cli-documentation/whoami
+  - /cli/cli-commands/npm-whoami
+  - /cli/cli-commands/whoami
+  - /cli/commands/npm-whoami
   - /cli/commands/whoami
+  - /cli/npm-whoami
+  - /cli/v8/cli-commands/npm-whoami
+  - /cli/v8/cli-commands/whoami
+  - /cli/v8/commands/whoami
+  - /cli/v8/npm-whoami
+  - /cli/v8/whoami
   - /cli/whoami
-  - /cli/whoami.html
+  - /commands/npm-whoami
+  - /commands/whoami
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npm.md
+++ b/content/cli/v8/commands/npm.md
@@ -7,10 +7,18 @@ github_branch: v8
 github_path: docs/content/commands/npm.md
 redirect_from:
   - /cli-commands/npm
-  - /cli-commands/npm.html
+  - /cli-documentation/cli-commands/npm
+  - /cli-documentation/commands/npm
+  - /cli-documentation/npm
+  - /cli-documentation/v8/cli-commands/npm
+  - /cli-documentation/v8/commands/npm
+  - /cli-documentation/v8/npm
+  - /cli/cli-commands/npm
   - /cli/commands/npm
   - /cli/npm
-  - /cli/npm.html
+  - /cli/v8/cli-commands/npm
+  - /cli/v8/npm
+  - /commands/npm
 ---
 
 ### Synopsis

--- a/content/cli/v8/commands/npx.md
+++ b/content/cli/v8/commands/npx.md
@@ -5,6 +5,20 @@ description: Run a command from a local or remote npm package
 github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/commands/npx.md
+redirect_from:
+  - /cli-commands/npx
+  - /cli-documentation/cli-commands/npx
+  - /cli-documentation/commands/npx
+  - /cli-documentation/npx
+  - /cli-documentation/v8/cli-commands/npx
+  - /cli-documentation/v8/commands/npx
+  - /cli-documentation/v8/npx
+  - /cli/cli-commands/npx
+  - /cli/commands/npx
+  - /cli/npx
+  - /cli/v8/cli-commands/npx
+  - /cli/v8/npx
+  - /commands/npx
 ---
 
 ### Synopsis

--- a/content/cli/v8/configuring-npm/folders.md
+++ b/content/cli/v8/configuring-npm/folders.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/configuring-npm/folders.md
 redirect_from:
+  - /cli-documentation/configuring-npm/folders
+  - /cli-documentation/files/folders
+  - /cli-documentation/v8/configuring-npm/folders
+  - /cli-documentation/v8/files/folders
+  - /cli/configuring-npm/folders
+  - /cli/files/folders
+  - /cli/v8/files/folders
   - /configuring-npm/folders
-  - /configuring-npm/folders.html
   - /files/folders
-  - /files/folders.html
 ---
 
 ### Description

--- a/content/cli/v8/configuring-npm/index.mdx
+++ b/content/cli/v8/configuring-npm/index.mdx
@@ -5,9 +5,24 @@ github_branch: v8
 github_path: docs/nav.yml
 redirect_from:
   - /cli-documentation/configuring-npm
+  - /cli-documentation/configuring-npm/index
   - /cli-documentation/files
+  - /cli-documentation/files/index
+  - /cli-documentation/v8/configuring-npm
+  - /cli-documentation/v8/configuring-npm/index
+  - /cli-documentation/v8/files
+  - /cli-documentation/v8/files/index
   - /cli/configuring-npm
+  - /cli/configuring-npm/index
+  - /cli/files
+  - /cli/files/index
+  - /cli/v8/configuring-npm/index
+  - /cli/v8/files
+  - /cli/v8/files/index
   - /configuring-npm
+  - /configuring-npm/index
+  - /files
+  - /files/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v8/configuring-npm/install.md
+++ b/content/cli/v8/configuring-npm/install.md
@@ -6,8 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/configuring-npm/install.md
 redirect_from:
+  - /cli-documentation/configuring-npm/install
+  - /cli-documentation/files/install
+  - /cli-documentation/v8/configuring-npm/install
+  - /cli-documentation/v8/files/install
+  - /cli/configuring-npm/install
+  - /cli/files/install
+  - /cli/v8/files/install
   - /configuring-npm/install
-  - /configuring-npm/install.html
+  - /files/install
 ---
 
 ### Description

--- a/content/cli/v8/configuring-npm/npm-shrinkwrap-json.md
+++ b/content/cli/v8/configuring-npm/npm-shrinkwrap-json.md
@@ -6,8 +6,25 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/configuring-npm/npm-shrinkwrap-json.md
 redirect_from:
+  - /cli-documentation/configuring-npm/npm-shrinkwrap-json
+  - /cli-documentation/configuring-npm/npm-shrinkwrap.json
+  - /cli-documentation/files/npm-shrinkwrap-json
+  - /cli-documentation/files/npm-shrinkwrap.json
+  - /cli-documentation/v8/configuring-npm/npm-shrinkwrap-json
+  - /cli-documentation/v8/configuring-npm/npm-shrinkwrap.json
+  - /cli-documentation/v8/files/npm-shrinkwrap-json
+  - /cli-documentation/v8/files/npm-shrinkwrap.json
+  - /cli/configuring-npm/npm-shrinkwrap-json
+  - /cli/configuring-npm/npm-shrinkwrap.json
+  - /cli/files/npm-shrinkwrap-json
+  - /cli/files/npm-shrinkwrap.json
+  - /cli/v8/configuring-npm/npm-shrinkwrap.json
+  - /cli/v8/files/npm-shrinkwrap-json
+  - /cli/v8/files/npm-shrinkwrap.json
   - /configuring-npm/npm-shrinkwrap-json
-  - /configuring-npm/npm-shrinkwrap-json.html
+  - /configuring-npm/npm-shrinkwrap.json
+  - /files/npm-shrinkwrap-json
+  - /files/npm-shrinkwrap.json
 ---
 
 ### Description

--- a/content/cli/v8/configuring-npm/npmrc.md
+++ b/content/cli/v8/configuring-npm/npmrc.md
@@ -6,11 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/configuring-npm/npmrc.md
 redirect_from:
+  - /cli-documentation/configuring-npm/npmrc
   - /cli-documentation/files/npmrc
+  - /cli-documentation/v8/configuring-npm/npmrc
+  - /cli-documentation/v8/files/npmrc
+  - /cli/configuring-npm/npmrc
+  - /cli/files/npmrc
+  - /cli/v8/files/npmrc
   - /configuring-npm/npmrc
-  - /configuring-npm/npmrc.html
   - /files/npmrc
-  - /files/npmrc.html
 ---
 
 ### Description

--- a/content/cli/v8/configuring-npm/package-json.md
+++ b/content/cli/v8/configuring-npm/package-json.md
@@ -6,12 +6,25 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/configuring-npm/package-json.md
 redirect_from:
+  - /cli-documentation/configuring-npm/package-json
+  - /cli-documentation/configuring-npm/package.json
+  - /cli-documentation/files/package-json
+  - /cli-documentation/files/package.json
+  - /cli-documentation/v8/configuring-npm/package-json
+  - /cli-documentation/v8/configuring-npm/package.json
+  - /cli-documentation/v8/files/package-json
+  - /cli-documentation/v8/files/package.json
+  - /cli/configuring-npm/package-json
+  - /cli/configuring-npm/package.json
+  - /cli/files/package-json
+  - /cli/files/package.json
+  - /cli/v8/configuring-npm/package.json
+  - /cli/v8/files/package-json
+  - /cli/v8/files/package.json
   - /configuring-npm/package-json
-  - /configuring-npm/package-json.html
   - /configuring-npm/package.json
-  - /creating-a-packge-json-file
+  - /files/package-json
   - /files/package.json
-  - /files/package.json.html
 ---
 
 ### Description

--- a/content/cli/v8/configuring-npm/package-lock-json.md
+++ b/content/cli/v8/configuring-npm/package-lock-json.md
@@ -6,10 +6,25 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/configuring-npm/package-lock-json.md
 redirect_from:
+  - /cli-documentation/configuring-npm/package-lock-json
+  - /cli-documentation/configuring-npm/package-lock.json
+  - /cli-documentation/files/package-lock-json
+  - /cli-documentation/files/package-lock.json
+  - /cli-documentation/v8/configuring-npm/package-lock-json
+  - /cli-documentation/v8/configuring-npm/package-lock.json
+  - /cli-documentation/v8/files/package-lock-json
+  - /cli-documentation/v8/files/package-lock.json
+  - /cli/configuring-npm/package-lock-json
+  - /cli/configuring-npm/package-lock.json
+  - /cli/files/package-lock-json
+  - /cli/files/package-lock.json
+  - /cli/v8/configuring-npm/package-lock.json
+  - /cli/v8/files/package-lock-json
+  - /cli/v8/files/package-lock.json
   - /configuring-npm/package-lock-json
-  - /configuring-npm/package-lock-json.html
+  - /configuring-npm/package-lock.json
+  - /files/package-lock-json
   - /files/package-lock.json
-  - /files/package-lock.json.html
 ---
 
 ### Description

--- a/content/cli/v8/index.mdx
+++ b/content/cli/v8/index.mdx
@@ -6,6 +6,11 @@ github_path: docs/nav.yml
 redirect_from:
   - /cli
   - /cli-documentation
+  - /cli-documentation/index
+  - /cli-documentation/v8
+  - /cli-documentation/v8/index
+  - /cli/index
+  - /cli/v8/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v8/using-npm/config.md
+++ b/content/cli/v8/using-npm/config.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/config.md
 redirect_from:
+  - /cli-documentation/misc/config
+  - /cli-documentation/using-npm/config
+  - /cli-documentation/v8/misc/config
+  - /cli-documentation/v8/using-npm/config
+  - /cli/misc/config
+  - /cli/using-npm/config
+  - /cli/v8/misc/config
   - /misc/config
-  - /misc/config.html
   - /using-npm/config
-  - /using-npm/config.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/dependency-selectors.md
+++ b/content/cli/v8/using-npm/dependency-selectors.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/dependency-selectors.md
 redirect_from:
+  - /cli-documentation/misc/dependency-selectors
+  - /cli-documentation/using-npm/dependency-selectors
+  - /cli-documentation/v8/misc/dependency-selectors
+  - /cli-documentation/v8/using-npm/dependency-selectors
+  - /cli/misc/dependency-selectors
+  - /cli/using-npm/dependency-selectors
+  - /cli/v8/misc/dependency-selectors
   - /misc/dependency-selectors
-  - /misc/dependency-selectors.html
   - /using-npm/dependency-selectors
-  - /using-npm/dependency-selectors.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/developers.md
+++ b/content/cli/v8/using-npm/developers.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/developers.md
 redirect_from:
+  - /cli-documentation/misc/developers
+  - /cli-documentation/using-npm/developers
+  - /cli-documentation/v8/misc/developers
+  - /cli-documentation/v8/using-npm/developers
+  - /cli/misc/developers
+  - /cli/using-npm/developers
+  - /cli/v8/misc/developers
   - /misc/developers
-  - /misc/developers.html
   - /using-npm/developers
-  - /using-npm/developers.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/index.mdx
+++ b/content/cli/v8/using-npm/index.mdx
@@ -5,10 +5,24 @@ github_branch: v8
 github_path: docs/nav.yml
 redirect_from:
   - /cli-documentation/misc
+  - /cli-documentation/misc/index
   - /cli-documentation/using-npm
+  - /cli-documentation/using-npm/index
+  - /cli-documentation/v8/misc
+  - /cli-documentation/v8/misc/index
+  - /cli-documentation/v8/using-npm
+  - /cli-documentation/v8/using-npm/index
+  - /cli/misc
+  - /cli/misc/index
   - /cli/using-npm
-  - /misc/index.html
+  - /cli/using-npm/index
+  - /cli/v8/misc
+  - /cli/v8/misc/index
+  - /cli/v8/using-npm/index
+  - /misc
+  - /misc/index
   - /using-npm
+  - /using-npm/index
 ---
 
 <Index depth="1" />

--- a/content/cli/v8/using-npm/logging.md
+++ b/content/cli/v8/using-npm/logging.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/logging.md
 redirect_from:
+  - /cli-documentation/misc/logging
+  - /cli-documentation/using-npm/logging
+  - /cli-documentation/v8/misc/logging
+  - /cli-documentation/v8/using-npm/logging
+  - /cli/misc/logging
+  - /cli/using-npm/logging
+  - /cli/v8/misc/logging
   - /misc/logging
-  - /misc/logging.html
   - /using-npm/logging
-  - /using-npm/logging.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/orgs.md
+++ b/content/cli/v8/using-npm/orgs.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/orgs.md
 redirect_from:
+  - /cli-documentation/misc/orgs
+  - /cli-documentation/using-npm/orgs
+  - /cli-documentation/v8/misc/orgs
+  - /cli-documentation/v8/using-npm/orgs
+  - /cli/misc/orgs
+  - /cli/using-npm/orgs
+  - /cli/v8/misc/orgs
   - /misc/orgs
-  - /misc/orgs.html
   - /using-npm/orgs
-  - /using-npm/orgs.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/package-spec.md
+++ b/content/cli/v8/using-npm/package-spec.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/package-spec.md
 redirect_from:
+  - /cli-documentation/misc/package-spec
+  - /cli-documentation/using-npm/package-spec
+  - /cli-documentation/v8/misc/package-spec
+  - /cli-documentation/v8/using-npm/package-spec
+  - /cli/misc/package-spec
+  - /cli/using-npm/package-spec
+  - /cli/v8/misc/package-spec
   - /misc/package-spec
-  - /misc/package-spec.html
   - /using-npm/package-spec
-  - /using-npm/package-spec.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/registry.md
+++ b/content/cli/v8/using-npm/registry.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/registry.md
 redirect_from:
+  - /cli-documentation/misc/registry
+  - /cli-documentation/using-npm/registry
+  - /cli-documentation/v8/misc/registry
+  - /cli-documentation/v8/using-npm/registry
+  - /cli/misc/registry
+  - /cli/using-npm/registry
+  - /cli/v8/misc/registry
   - /misc/registry
-  - /misc/registry.html
   - /using-npm/registry
-  - /using-npm/registry.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/removal.md
+++ b/content/cli/v8/using-npm/removal.md
@@ -6,12 +6,25 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/removal.md
 redirect_from:
+  - /cli-documentation/misc/removal
+  - /cli-documentation/misc/removing-npm
+  - /cli-documentation/using-npm/removal
+  - /cli-documentation/using-npm/removing-npm
+  - /cli-documentation/v8/misc/removal
+  - /cli-documentation/v8/misc/removing-npm
+  - /cli-documentation/v8/using-npm/removal
+  - /cli-documentation/v8/using-npm/removing-npm
+  - /cli/misc/removal
+  - /cli/misc/removing-npm
+  - /cli/using-npm/removal
+  - /cli/using-npm/removing-npm
+  - /cli/v8/misc/removal
+  - /cli/v8/misc/removing-npm
+  - /cli/v8/using-npm/removing-npm
   - /misc/removal
-  - /misc/removal.html
   - /misc/removing-npm
-  - /misc/removing-npm.html
   - /using-npm/removal
-  - /using-npm/removal.html
+  - /using-npm/removing-npm
 ---
 
 ### Synopsis

--- a/content/cli/v8/using-npm/scope.md
+++ b/content/cli/v8/using-npm/scope.md
@@ -6,11 +6,25 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/scope.md
 redirect_from:
+  - /cli-documentation/misc/npm-scope
+  - /cli-documentation/misc/scope
+  - /cli-documentation/using-npm/npm-scope
+  - /cli-documentation/using-npm/scope
+  - /cli-documentation/v8/misc/npm-scope
+  - /cli-documentation/v8/misc/scope
+  - /cli-documentation/v8/using-npm/npm-scope
+  - /cli-documentation/v8/using-npm/scope
+  - /cli/misc/npm-scope
+  - /cli/misc/scope
+  - /cli/using-npm/npm-scope
+  - /cli/using-npm/scope
+  - /cli/v8/misc/npm-scope
+  - /cli/v8/misc/scope
+  - /cli/v8/using-npm/npm-scope
+  - /misc/npm-scope
   - /misc/scope
-  - /misc/scope.html
   - /using-npm/npm-scope
   - /using-npm/scope
-  - /using-npm/scope.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/scripts.md
+++ b/content/cli/v8/using-npm/scripts.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/scripts.md
 redirect_from:
+  - /cli-documentation/misc/scripts
+  - /cli-documentation/using-npm/scripts
+  - /cli-documentation/v8/misc/scripts
+  - /cli-documentation/v8/using-npm/scripts
+  - /cli/misc/scripts
+  - /cli/using-npm/scripts
+  - /cli/v8/misc/scripts
   - /misc/scripts
-  - /misc/scripts.html
   - /using-npm/scripts
-  - /using-npm/scripts.html
 ---
 
 ### Description

--- a/content/cli/v8/using-npm/workspaces.md
+++ b/content/cli/v8/using-npm/workspaces.md
@@ -6,10 +6,15 @@ github_repo: npm/cli
 github_branch: v8
 github_path: docs/content/using-npm/workspaces.md
 redirect_from:
+  - /cli-documentation/misc/workspaces
+  - /cli-documentation/using-npm/workspaces
+  - /cli-documentation/v8/misc/workspaces
+  - /cli-documentation/v8/using-npm/workspaces
+  - /cli/misc/workspaces
+  - /cli/using-npm/workspaces
+  - /cli/v8/misc/workspaces
   - /misc/workspaces
-  - /misc/workspaces.html
   - /using-npm/workspaces
-  - /using-npm/workspaces.html
 ---
 
 ### Description

--- a/package-lock.json
+++ b/package-lock.json
@@ -51601,7 +51601,7 @@
         "github-slugger": "^1.2.1",
         "html-react-parser": "^0.9.1",
         "jest": "^29.1.2",
-        "jest-environment-jsdom": "*",
+        "jest-environment-jsdom": "^29.1.2",
         "lodash.debounce": "4.0.8",
         "lodash.uniqby": "^4.7.0",
         "pkg-up": "^3.1.0",

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -29,7 +29,6 @@ exports.createSchemaCustomization = ({actions: {createTypes}}) => {
 exports.createPages = async ({graphql, actions}, themeOptions) => {
   const repo = themeOptions.repo ? themeOptions.repo : { url: getPkgRepo(readPkgUp.sync().package).browse() };
 
-
   const {data} = await graphql(`
     {
       allMdx {
@@ -106,6 +105,15 @@ exports.createPages = async ({graphql, actions}, themeOptions) => {
             isPermanent: true,
             redirectInBrowser: true
           })
+
+          if (pagePath.startsWith('cli/') && !from.endsWith('index')) {
+            actions.createRedirect({
+              fromPath: `${from}.html`,
+              toPath: '/' + pagePath,
+              isPermanent: true,
+              redirectInBrowser: true
+            })
+          }
         })
       }
     }),


### PR DESCRIPTION
This takes the old redirects and adds logic so that all possible
redirects are created for all releases. Generally redirects should be
discoverable, so that if `/cli/audit` redirects to
`/cli/v8/commands/npm-audit`, then the following redirects should also work:

- `/cli/npm-audit`
- `/cli/commands/audit`
- `/cli/v8/commands/audit`
- etc

And for redirects that contain a version id, they should also work for
non-default versions such as `/cli/v8/commands/audit` redirecting to
`/cli/v7/commands/npm-audit`.