### PR TITLE
tab index implemented for each variant item

### DIFF
--- a/src/theme/nav.yml
+++ b/src/theme/nav.yml
@@ -287,6 +287,7 @@
   variants:
     - title: Version 6.14.17 (Legacy Release)
       shortName: v6
+      tabIndex: 1
       url: /cli/v6
       children:
         - title: CLI Commands
@@ -525,6 +526,7 @@
               description: Cleaning the slate
     - title: Version 7.24.2 (Legacy Release)
       shortName: v7
+      tabIndex: 2
       url: /cli/v7
       children:
         - title: CLI Commands
@@ -779,6 +781,7 @@
     - title: Version 8.19.2 (Current Release)
       shortName: v8
       url: /cli/v8
+      tabIndex: 3
       default: true
       children:
         - title: CLI Commands

--- a/theme/src/components/variant-select.js
+++ b/theme/src/components/variant-select.js
@@ -29,12 +29,21 @@ function VariantSelect(props) {
       return null;
   }
 
-  variantPages.forEach((match) => {
+  /** 
+   *  We should use '@primer/react' package, as '@primer/components' package depricated and moved to '@primer/react'.
+   *  We have no closing/opening control with current '@primer/components' package, so document.body click event used for closing purpose.
+   */
+  // TODO: We should use 'setOpen' function returned by the useDetails hook when we move to '@primer/react' package. https://primer.style/react/deprecated/Dropdown
+  function collapseDropdown () {
+    document.body.click()
+  }
+
+  variantPages.forEach((match, index) => {
       if (match.page.url === path) {
           selectedItem = match;
       }
 
-      items.push(<Dropdown.Item tabIndex={match.variant.tabIndex} onClick={() => { window.location.href = match.page.url; }} key={match.variant.title}>{match.variant.title}</Dropdown.Item>);
+      items.push(<Dropdown.Item onBlur={index === (variantPages.length - 1) ? collapseDropdown : undefined} tabIndex={match.variant.tabIndex} onClick={() => { window.location.href = match.page.url; }} key={match.variant.title}>{match.variant.title}</Dropdown.Item>);
   });
 
   return (

--- a/theme/src/components/variant-select.js
+++ b/theme/src/components/variant-select.js
@@ -34,7 +34,7 @@ function VariantSelect(props) {
           selectedItem = match;
       }
 
-      items.push(<Dropdown.Item onClick={() => { window.location.href = match.page.url; }} key={match.variant.title}>{match.variant.title}</Dropdown.Item>);
+      items.push(<Dropdown.Item tabIndex={match.variant.tabIndex} onClick={() => { window.location.href = match.page.url; }} key={match.variant.title}>{match.variant.title}</Dropdown.Item>);
   });
 
   return (


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
# Description
Upon pressing tab key, the focus moves to the list items available under 'version' dropdown.

# Result

https://user-images.githubusercontent.com/91082111/195274849-effa07ea-10d8-492b-b18f-29c843766da4.mov

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes: https://github.com/github/accessibility-audits/issues/2797
