### PR TITLE
tabindexes implemented

### DIFF
--- a/src/theme/nav.yml
+++ b/src/theme/nav.yml
@@ -287,6 +287,7 @@
   variants:
     - title: Version 6.14.17 (Legacy Release)
       shortName: v6
+      tabIndex: 1
       url: /cli/v6
       default: false
       children:
@@ -527,6 +528,7 @@
     - title: Version 7.24.2 (Legacy Release)
       shortName: v7
       url: /cli/v7
+      tabIndex: 2
       default: false
       children:
         - title: CLI Commands
@@ -781,6 +783,7 @@
     - title: Version 8.19.2 (Latest Release)
       shortName: v8
       url: /cli/v8
+      tabIndex: 3
       default: true
       children:
         - title: CLI Commands
@@ -1048,6 +1051,7 @@
       shortName: v9
       url: /cli/v9
       default: false
+      tabIndex: 4
       children:
         - title: CLI Commands
           shortName: Commands

--- a/theme/src/components/variant-select.js
+++ b/theme/src/components/variant-select.js
@@ -34,7 +34,7 @@ function VariantSelect(props) {
           selectedItem = match;
       }
 
-      items.push(<Dropdown.Item onClick={() => { window.location.href = match.page.url; }} key={match.variant.title}>{match.variant.title}</Dropdown.Item>);
+      items.push(<Dropdown.Item tabIndex={match.variant.tabIndex} onClick={() => { window.location.href = match.page.url; }} key={match.variant.title}>{match.variant.title}</Dropdown.Item>);
   });
 
   return (


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
## Description
The dropdown list items- 'Version 6.x (Legacy release)', 'Version 7.x (Legacy release)' and 'Version 8x (Current release)' present inside 'Version 8x (Current release)' combo box are not accessible through keyboard.

https://user-images.githubusercontent.com/91082111/197230616-2ad8828d-e12d-454f-83c0-47e270f855cf.mov


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Issue: https://github.com/github/accessibility-audits/issues/2794
