### PR TITLE
Default {prefix} on Windows should be %ProgramFiles%\nodejs.

### DIFF
--- a/content/cli/v6/configuring-npm/folders.md
+++ b/content/cli/v6/configuring-npm/folders.md
@@ -30,7 +30,7 @@ This document will tell you what it puts where.
 #### prefix Configuration
 
 The `prefix` config defaults to the location where node is installed.
-On most systems, this is `/usr/local`. On Windows, it's `%AppData%\npm`.
+On most systems, this is `/usr/local`. On Windows, it's `%ProgramFiles%\nodejs`.
 On Unix systems, it's one level up, since node is typically installed at
 `{prefix}/bin/node` rather than `{prefix}/node.exe`.
 

--- a/content/cli/v7/configuring-npm/folders.md
+++ b/content/cli/v7/configuring-npm/folders.md
@@ -30,7 +30,7 @@ This document will tell you what it puts where.
 #### prefix Configuration
 
 The `prefix` config defaults to the location where node is installed.
-On most systems, this is `/usr/local`. On Windows, it's `%AppData%\npm`.
+On most systems, this is `/usr/local`. On Windows, it's `%ProgramFiles%\nodejs`.
 On Unix systems, it's one level up, since node is typically installed at
 `{prefix}/bin/node` rather than `{prefix}/node.exe`.
 

--- a/content/cli/v8/configuring-npm/folders.md
+++ b/content/cli/v8/configuring-npm/folders.md
@@ -36,7 +36,7 @@ This document will tell you what it puts where.
 #### prefix Configuration
 
 The `prefix` config defaults to the location where node is installed.
-On most systems, this is `/usr/local`. On Windows, it's `%AppData%\npm`.
+On most systems, this is `/usr/local`. On Windows, it's `%ProgramFiles%\nodejs`.
 On Unix systems, it's one level up, since node is typically installed at
 `{prefix}/bin/node` rather than `{prefix}/node.exe`.
 

--- a/content/cli/v9/configuring-npm/folders.md
+++ b/content/cli/v9/configuring-npm/folders.md
@@ -31,7 +31,7 @@ This document will tell you what it puts where.
 
 The [`prefix` config](/cli/v9/using-npm/config#prefix) defaults to the location where
 node is installed. On most systems, this is `/usr/local`. On Windows, it's
-`%AppData%\npm`. On Unix systems, it's one level up, since node is typically
+`%ProgramFiles%\nodejs`. On Unix systems, it's one level up, since node is typically
 installed at `{prefix}/bin/node` rather than `{prefix}/node.exe`.
 
 When the `global` flag is set, npm installs things into this prefix.


### PR DESCRIPTION
Hello,

i changed the default {prefix} value on Windows because current doc says it is **`%AppData%\npm`** but globally installed packages are by default stored under `%ProgramFiles%/nodejs/node_modules` so {prefix} should be **`%ProgramFiles%/nodejs`**.

**What current doc says:**
> prefix Configuration
> The prefix config defaults to the location where node is installed. On most systems, this is /usr/local. **On Windows, it's %AppData%\npm.** On Unix systems, it's one level up, since node is typically installed at {prefix}/bin/node rather than {prefix}/node.exe.