### PR TITLE
Better npx link

### DIFF
--- a/content/about-npm/index.mdx
+++ b/content/about-npm/index.mdx
@@ -22,7 +22,7 @@ The [*registry*](https://docs.npmjs.com/misc/registry) is a large public databas
 
 * Adapt packages of code for your apps, or incorporate packages as they are.
 * Download standalone tools you can use right away.
-* Run packages without downloading using [npx](https://www.npmjs.com/package/npx).
+* Run packages without downloading using [npx](https://docs.npmjs.com/cli/v8/commands/npx).
 * Share code with any npm user, anywhere.
 * Restrict code to specific developers.
 * Create organizations to coordinate package maintenance, coding, and developers.

--- a/content/about-npm/index.mdx
+++ b/content/about-npm/index.mdx
@@ -22,7 +22,7 @@ The [*registry*](https://docs.npmjs.com/misc/registry) is a large public databas
 
 * Adapt packages of code for your apps, or incorporate packages as they are.
 * Download standalone tools you can use right away.
-* Run packages without downloading using [npx](https://docs.npmjs.com/cli/v8/commands/npx).
+* Run packages without downloading using [npx](https://docs.npmjs.com/cli/commands/npx).
 * Share code with any npm user, anywhere.
 * Restrict code to specific developers.
 * Create organizations to coordinate package maintenance, coding, and developers.

--- a/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
@@ -68,7 +68,7 @@ NPM_CONFIG_PREFIX=~/.npm-global
 
 **npx: an alternative to running global commands**
 
-If you are using npm version 5.2 or greater, you may want to consider [npx](https://docs.npmjs.com/cli/v8/commands/npx) as an alternative way to run global commands, especially if you only need a command occasionally. For more information, see [this article about npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
+If you are using npm version 5.2 or greater, you may want to consider [npx](https://docs.npmjs.com/cli/commands/npx) as an alternative way to run global commands, especially if you only need a command occasionally. For more information, see [this article about npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
 </Note>
 

--- a/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
@@ -68,7 +68,7 @@ NPM_CONFIG_PREFIX=~/.npm-global
 
 **npx: an alternative to running global commands**
 
-If you are using npm version 5.2 or greater, you may want to consider [npx](https://www.npmjs.com/package/npx) as an alternative way to run global commands, especially if you only need a command occasionally. For more information, see [this article about npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
+If you are using npm version 5.2 or greater, you may want to consider [npx](https://docs.npmjs.com/cli/v8/commands/npx) as an alternative way to run global commands, especially if you only need a command occasionally. For more information, see [this article about npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 
 </Note>
 

--- a/content/policies/privacy.mdx
+++ b/content/policies/privacy.mdx
@@ -32,7 +32,7 @@ If you find yourself in a jam,
 npm collects data about you:
 
 -   when you use the [npm command](https://www.npmjs.com/package/npm), 
-    the [npx command](https://www.npmjs.com/package/npx) or another 
+    the [npx command](https://docs.npmjs.com/cli/v8/commands/npx) or another 
     program to access the [npm public registry](https://registry.npmjs.org/), 
     [Enterprise registries that npm hosts](https://www.npmjs.com/enterprise), 
     [private packages](https://www.npmjs.com/features), 

--- a/content/policies/privacy.mdx
+++ b/content/policies/privacy.mdx
@@ -32,7 +32,7 @@ If you find yourself in a jam,
 npm collects data about you:
 
 -   when you use the [npm command](https://www.npmjs.com/package/npm), 
-    the [npx command](https://docs.npmjs.com/cli/v8/commands/npx) or another 
+    the [npx command](https://docs.npmjs.com/cli/commands/npx) or another 
     program to access the [npm public registry](https://registry.npmjs.org/), 
     [Enterprise registries that npm hosts](https://www.npmjs.com/enterprise), 
     [private packages](https://www.npmjs.com/features), 


### PR DESCRIPTION
Continuation of https://github.com/npm/cli/pull/5742

Old link goes to:
https://www.npmjs.com/package/npx
... which is a bit cryptic. Following the link to GitHub goes to:
https://github.com/npm/npx
... which shows:
>This repository has been archived by the owner. It is now read-only.

... up top. Scrolling down reveals:
>⚠️ DEPRECATED: This project has been deprecated - npx is now part of the [npm cli](https://github.com/npm/cli)

... that leads to:
https://github.com/npm/cli
The sidebar gives the link to:
https://docs.npmjs.com/cli/
... and then you just have to search for "npx" (or drill down into "CLI Commands"), and then finally, you get to:
https://docs.npmjs.com/cli/v8/commands/npx