### PR TITLE
Remove /v7/ from link (evergreen🌲)

### DIFF
--- a/content/packages-and-modules/updating-and-managing-your-published-packages/unpublishing-packages-from-the-registry.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/unpublishing-packages-from-the-registry.mdx
@@ -3,7 +3,7 @@ title: Unpublishing packages from the registry
 ---
 import shared from '../../../src/shared.js'
 
-As a package owner or collaborator, if your package has no dependents, you can permanently remove it from the npm registry by using the CLI. You can [unpublish](https://docs.npmjs.com/cli/v7/commands/npm-unpublish) within 72 hours of the initial publish; beyond 72 hours, you can still unpublish your package if [it meets certain criteria](https://www.npmjs.com/policies/unpublish).
+As a package owner or collaborator, if your package has no dependents, you can permanently remove it from the npm registry by using the CLI. You can [unpublish](https://docs.npmjs.com/cli/commands/npm-unpublish) within 72 hours of the initial publish; beyond 72 hours, you can still unpublish your package if [it meets certain criteria](https://www.npmjs.com/policies/unpublish).
 
 These criteria are set to avoid damaging the JavaScript package ecosystem.  If you cannot unpublish your package, you can [deprecate it instead](/deprecating-and-undeprecating-packages-or-package-versions).
 


### PR DESCRIPTION
[As per @wraithgar](https://github.com/npm/cli/pull/5742#issuecomment-1290620118)

```diff
- https://docs.npmjs.com/cli/v7/commands/npm-unpublish
+ https://docs.npmjs.com/cli/commands/npm-unpublish
```