### PR TITLE
color ratio fixed

### DIFF
--- a/theme/src/components/clipboard-copy.js
+++ b/theme/src/components/clipboard-copy.js
@@ -1,7 +1,14 @@
-import {Button, StyledOcticon} from '@primer/components'
+import {Button, StyledOcticon, themeGet} from '@primer/components'
 import {CheckIcon, CopyIcon} from '@primer/octicons-react'
+import styled from 'styled-components'
 import copy from 'copy-to-clipboard'
 import React from 'react'
+
+const CopyToClipboard = styled(Button)`
+  &:focus {
+    box-shadow: 0 0 0 3px ${themeGet('colors.blue.5')};
+  }
+`
 
 function ClipboardCopy({value}) {
   const [copied, setCopied] = React.useState(false)
@@ -15,7 +22,7 @@ function ClipboardCopy({value}) {
   }, [copied])
 
   return (
-    <Button
+    <CopyToClipboard
       aria-label="Copy to clipboard"
       onClick={() => {
         copy(value)
@@ -23,7 +30,7 @@ function ClipboardCopy({value}) {
       }}
     >
       {copied ? <StyledOcticon icon={CheckIcon} color="green.5" /> : <StyledOcticon icon={CopyIcon} color="gray.7" />}
-    </Button>
+    </CopyToClipboard>
   )
 }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Luminosity ratio of focus indicator for ‘Copy to clipboard’ button should be more than 3:1 for the keyboard focus indicator to pass the required ratio.

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/91082111/199176940-558e4869-727a-4e5c-bf54-92719594ca7d.png">

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Issue: https://github.com/github/accessibility-audits/issues/2792