### PR TITLE
A11y: announce copy to clipboard action

### DIFF
--- a/theme/src/aria-live.js
+++ b/theme/src/aria-live.js
@@ -6,16 +6,16 @@
  * The code is heavily borrowed from https://github.com/github/github/blob/master/app/assets/modules/github/aria-live.ts
  */
 
- let container
+let container
 
- if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined') {
   document.addEventListener("DOMContentLoaded", function(event) { 
     createNoticeContainer()
   });
  }
  
  // Announce message update to screen reader.
- function announce(message) {
+function announce(message) {
    if (!container || !container.isConnected) {
      /* This condition is for when the aria-live container no longer exists due to nav methods like turbo drive
      which replace the body getting rid of the region. We add the container if it's missing. We then add a delay
@@ -33,7 +33,7 @@
  }
  
  // Set aria-live container to message.
- function setContainerContent(message) {
+function setContainerContent(message) {
    if (!container) return
    if (container.textContent === message) {
      /* This is a hack due to the way the aria live API works.
@@ -42,14 +42,13 @@
      the browser that the live region has updated,
      which will cause it to read again, but with no audible difference. */
      container.textContent = `${message}\u00A0`
- 
    } else {
      container.textContent = message
    }
  }
  
  // Get the global screen reader notice container.
- function createNoticeContainer() {
+function createNoticeContainer() {
    container = document.createElement('div')
    container.setAttribute('aria-live', 'polite')
    container.style.position = 'absolute'
@@ -63,7 +62,7 @@
    document.body.append(container)
  }
  
- module.exports = {
+module.exports = {
    announce
  }
  

--- a/theme/src/aria-live.js
+++ b/theme/src/aria-live.js
@@ -1,0 +1,62 @@
+/**
+ * This is an implementation of the
+ * aria-live guide:
+ * https://github.com/github/thehub/blob/main/docs/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/screenreaders/live-regions-and-screen-reader-announcements.md
+ * 
+ * The code is heavily borrowed from https://github.com/github/github/blob/master/app/assets/modules/github/aria-live.ts
+ */
+
+ let container
+
+ if (typeof window !== 'undefined') {
+  document.addEventListener("DOMContentLoaded", function(event) { 
+    createNoticeContainer()
+  });
+ }
+ 
+ // Announce message update to screen reader.
+ function announce(message) {
+   if (!container || !container.isConnected) {
+     /* This condition is for when the aria-live container no longer exists due to nav methods like turbo drive
+     which replace the body getting rid of the region. We add the container if it's missing. We then add a delay
+     to ensure aria-live can work correctly.
+     Note: This approach is not ideal and should be revisited.
+     See https://github.com/github/accessibility/issues/1900#issuecomment-1254369320
+     */
+     createNoticeContainer()
+     setTimeout(() => {
+       setContainerContent(message)
+     }, 200)
+   } else {
+     setContainerContent(message)
+   }
+ }
+ 
+ // Set aria-live container to message.
+ function setContainerContent(message) {
+   if (!container) return
+   if (container.textContent === message) {
+     /* This is a hack due to the way the aria live API works.
+     A screen reader will not read a live region again
+     if the text is the same. Adding a space character tells
+     the browser that the live region has updated,
+     which will cause it to read again, but with no audible difference. */
+     container.textContent = `${message}\u00A0`
+ 
+   } else {
+     container.textContent = message
+   }
+ }
+ 
+ // Get the global screen reader notice container.
+ function createNoticeContainer() {
+   container = document.createElement('div')
+   container.setAttribute('aria-live', 'polite')
+   container.classList.add('sr-only')
+   document.body.append(container)
+ }
+ 
+ module.exports = {
+   announce
+ }
+ 

--- a/theme/src/aria-live.js
+++ b/theme/src/aria-live.js
@@ -52,7 +52,14 @@
  function createNoticeContainer() {
    container = document.createElement('div')
    container.setAttribute('aria-live', 'polite')
-   container.classList.add('sr-only')
+   container.style.position = 'absolute'
+   container.style.width = '1px'
+   container.style.height = '1px'
+   container.style.padding = '0'
+   container.style.overflow = 'hidden'
+   container.style.clip = 'rect(0, 0, 0, 0)'
+   container.style.wordWrap = 'normal'
+   container.style.border = '0'
    document.body.append(container)
  }
  

--- a/theme/src/components/clipboard-copy.js
+++ b/theme/src/components/clipboard-copy.js
@@ -28,7 +28,7 @@ function ClipboardCopy({value}) {
       onClick={() => {
         copy(value)
         setCopied(true)
-        announce(`copied to clipboard`)
+        announce(`Copied to clipboard`)
       }}
     >
       {copied ? <StyledOcticon icon={CheckIcon} color="green.5" /> : <StyledOcticon icon={CopyIcon} color="gray.7" />}

--- a/theme/src/components/clipboard-copy.js
+++ b/theme/src/components/clipboard-copy.js
@@ -3,6 +3,7 @@ import {CheckIcon, CopyIcon} from '@primer/octicons-react'
 import styled from 'styled-components'
 import copy from 'copy-to-clipboard'
 import React from 'react'
+import {announce} from '../aria-live'
 
 const CopyToClipboard = styled(Button)`
   &:focus {
@@ -27,6 +28,7 @@ function ClipboardCopy({value}) {
       onClick={() => {
         copy(value)
         setCopied(true)
+        announce(`copied to clipboard`)
       }}
     >
       {copied ? <StyledOcticon icon={CheckIcon} color="green.5" /> : <StyledOcticon icon={CopyIcon} color="gray.7" />}


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Screen reader did not announce any information upon activating 'Copy to Clipboard' button, with this change it will.

Made as per this [great guiedline](https://github.com/github/thehub/blob/main/docs/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/screenreaders/live-regions-and-screen-reader-announcements.md).

## References
Related to https://github.com/github/accessibility-audits/issues/2795
<!-- Examples:

  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
