### PR TITLE
Changed `OS X` to `macOS`

### DIFF
--- a/content/getting-started/configuring-your-local-environment/downloading-and-installing-node-js-and-npm.mdx
+++ b/content/getting-started/configuring-your-local-environment/downloading-and-installing-node-js-and-npm.mdx
@@ -53,9 +53,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 
 If you use Linux, we recommend that you use a NodeSource installer.
 
-### OS X or Windows Node installers
+### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 ### Linux or other operating systems Node installers
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Documentation uses older name of Mac operating system i.e. no longer being used.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
