### PR TITLE
Fixes typo in link

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/specifying-dependencies-and-devdependencies-in-a-package-json-file.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/specifying-dependencies-and-devdependencies-in-a-package-json-file.mdx
@@ -58,6 +58,6 @@ To add devDependencies to a `package.json` file, in a text editor, add an attrib
 }
 ```
 
-[pkg-json]: creating-a-packge-json-file
+[pkg-json]: creating-a-package-json-file
 [semver]: about-semantic-versioning
 [semver-calc]: https://semver.npmjs.com/


### PR DESCRIPTION
`creating-a-packge-json-file` to `creating-a-package-json-file`

I'm not sure there is any further explanation needed.