### PR TITLE
CLI doc correction on npm-init.md

### DIFF
--- a/content/cli/v8/commands/npm-init.md
+++ b/content/cli/v8/commands/npm-init.md
@@ -6,26 +6,26 @@ github_repo: npm/cli
 github_branch: release/v8
 github_path: docs/lib/content/commands/npm-init.md
 redirect_from:
-  - /cli-documentation/v8/cli-commands/init
-  - /cli-documentation/v8/cli-commands/npm-init
-  - /cli-documentation/v8/commands/init
-  - /cli-documentation/v8/commands/npm-init
-  - /cli-documentation/v8/init
-  - /cli-documentation/v8/npm-init
-  - /cli/v8/cli-commands/init
-  - /cli/v8/cli-commands/npm-init
-  - /cli/v8/commands/init
-  - /cli/v8/init
-  - /cli/v8/npm-init
+    - /cli-documentation/v8/cli-commands/init
+    - /cli-documentation/v8/cli-commands/npm-init
+    - /cli-documentation/v8/commands/init
+    - /cli-documentation/v8/commands/npm-init
+    - /cli-documentation/v8/init
+    - /cli-documentation/v8/npm-init
+    - /cli/v8/cli-commands/init
+    - /cli/v8/cli-commands/npm-init
+    - /cli/v8/commands/init
+    - /cli/v8/init
+    - /cli/v8/npm-init
 ---
 
 ### Synopsis
 
 ```bash
-npm init <package-spec> (same as `npx <package-spec>)
+npm init <package-spec> (same as `npx <package-spec>`)
 npm init <@scope> (same as `npx <@scope>/create`)
 
-aliases: create, innit
+aliases: create, init
 ```
 
 ### Description
@@ -41,11 +41,11 @@ running any other initialization-related operations.
 The init command is transformed to a corresponding `npm exec` operation as
 follows:
 
-* `npm init foo` -> `npm exec create-foo`
-* `npm init @usr/foo` -> `npm exec @usr/create-foo`
-* `npm init @usr` -> `npm exec @usr/create`
-* `npm init @usr@2.0.0` -> `npm exec @usr/create@2.0.0`
-* `npm init @usr/foo@2.0.0` -> `npm exec @usr/create-foo@2.0.0`
+-   `npm init foo` -> `npm exec create-foo`
+-   `npm init @usr/foo` -> `npm exec @usr/create-foo`
+-   `npm init @usr` -> `npm exec @usr/create`
+-   `npm init @usr@2.0.0` -> `npm exec @usr/create@2.0.0`
+-   `npm init @usr/foo@2.0.0` -> `npm exec @usr/create-foo@2.0.0`
 
 If the initializer is omitted (by just calling `npm init`), init will fall
 back to legacy init behavior. It will ask you a bunch of questions, and
@@ -55,14 +55,14 @@ strictly additive, so it will keep any fields and values that were already
 set. You can also use `-y`/`--yes` to skip the questionnaire altogether. If
 you pass `--scope`, it will create a scoped package.
 
-*Note:* if a user already has the `create-<initializer>` package
-globally installed, that will be what `npm init` uses.  If you want npm
+_Note:_ if a user already has the `create-<initializer>` package
+globally installed, that will be what `npm init` uses. If you want npm
 to use the latest version, or another specific version you must specify
 it:
 
-* `npm init foo@latest` # fetches and runs the latest `create-foo` from
+-   `npm init foo@latest` # fetches and runs the latest `create-foo` from
     the registry
-* `npm init foo@1.2.3` #  runs `create-foo@1.2.3` specifically
+-   `npm init foo@1.2.3` # runs `create-foo@1.2.3` specifically
 
 #### Forwarding additional options
 
@@ -73,8 +73,8 @@ To better illustrate how options are forwarded, here's a more evolved
 example showing options passed to both the **npm cli** and a create package,
 both following commands are equivalent:
 
-- `npm init foo -y --registry=<url> -- --hello -a`
-- `npm exec -y --registry=<url> -- create-foo --hello -a`
+-   `npm init foo -y --registry=<url> -- --hello -a`
+-   `npm exec -y --registry=<url> -- create-foo --hello -a`
 
 ### Examples
 
@@ -173,42 +173,42 @@ dot to represent the current directory in that context, e.g: `react-app .`:
 
 #### `yes`
 
-* Default: null
-* Type: null or Boolean
+-   Default: null
+-   Type: null or Boolean
 
 Automatically answer "yes" to any prompts that npm might print on the
 command line.
 
 #### `force`
 
-* Default: false
-* Type: Boolean
+-   Default: false
+-   Type: Boolean
 
 Removes various protections against unfortunate side effects, common
 mistakes, unnecessary performance degradation, and malicious input.
 
-* Allow clobbering non-npm files in global installs.
-* Allow the `npm version` command to work on an unclean git repository.
-* Allow deleting the cache folder with `npm cache clean`.
-* Allow installing packages that have an `engines` declaration requiring a
-  different version of npm.
-* Allow installing packages that have an `engines` declaration requiring a
-  different version of `node`, even if `--engine-strict` is enabled.
-* Allow `npm audit fix` to install modules outside your stated dependency
-  range (including SemVer-major changes).
-* Allow unpublishing all versions of a published package.
-* Allow conflicting peerDependencies to be installed in the root project.
-* Implicitly set `--yes` during `npm init`.
-* Allow clobbering existing values in `npm pkg`
-* Allow unpublishing of entire packages (not just a single version).
+-   Allow clobbering non-npm files in global installs.
+-   Allow the `npm version` command to work on an unclean git repository.
+-   Allow deleting the cache folder with `npm cache clean`.
+-   Allow installing packages that have an `engines` declaration requiring a
+    different version of npm.
+-   Allow installing packages that have an `engines` declaration requiring a
+    different version of `node`, even if `--engine-strict` is enabled.
+-   Allow `npm audit fix` to install modules outside your stated dependency
+    range (including SemVer-major changes).
+-   Allow unpublishing all versions of a published package.
+-   Allow conflicting peerDependencies to be installed in the root project.
+-   Implicitly set `--yes` during `npm init`.
+-   Allow clobbering existing values in `npm pkg`
+-   Allow unpublishing of entire packages (not just a single version).
 
 If you don't have a clear idea of what you want to do, it is strongly
 recommended that you do not use this option!
 
 #### `scope`
 
-* Default: the scope of the current project, if any, or ""
-* Type: String
+-   Default: the scope of the current project, if any, or ""
+-   Type: String
 
 Associate an operation with a scope for a scoped registry.
 
@@ -234,11 +234,10 @@ This will also cause `npm init` to create a scoped package.
 npm init --scope=@foo --yes
 ```
 
-
 #### `workspace`
 
-* Default:
-* Type: String (can be set multiple times)
+-   Default:
+-   Type: String (can be set multiple times)
 
 Enable running a command in the context of the configured workspaces of the
 current project while filtering by running only the workspaces defined by
@@ -246,10 +245,10 @@ this configuration option.
 
 Valid values for the `workspace` config are either:
 
-* Workspace names
-* Path to a workspace directory
-* Path to a parent workspace directory (will result in selecting all
-  workspaces within that folder)
+-   Workspace names
+-   Path to a workspace directory
+-   Path to a parent workspace directory (will result in selecting all
+    workspaces within that folder)
 
 When set for the `npm init` command, this may be set to the folder of a
 workspace which does not yet exist, to create the folder and set it up as a
@@ -259,8 +258,8 @@ This value is not exported to the environment for child processes.
 
 #### `workspaces`
 
-* Default: null
-* Type: null or Boolean
+-   Default: null
+-   Type: null or Boolean
 
 Set to true to run the command in the context of **all** configured
 workspaces.
@@ -268,25 +267,25 @@ workspaces.
 Explicitly setting this to false will cause commands like `install` to
 ignore workspaces altogether. When not set explicitly:
 
-- Commands that operate on the `node_modules` tree (install, update, etc.)
-will link workspaces into the `node_modules` folder. - Commands that do
-other things (test, exec, publish, etc.) will operate on the root project,
-_unless_ one or more workspaces are specified in the `workspace` config.
+-   Commands that operate on the `node_modules` tree (install, update, etc.)
+    will link workspaces into the `node_modules` folder. - Commands that do
+    other things (test, exec, publish, etc.) will operate on the root project,
+    _unless_ one or more workspaces are specified in the `workspace` config.
 
 This value is not exported to the environment for child processes.
 
 #### `workspaces-update`
 
-* Default: true
-* Type: Boolean
+-   Default: true
+-   Type: Boolean
 
 If set to true, the npm cli will run an update after operations that may
 possibly change the workspaces installed to the `node_modules` folder.
 
 #### `include-workspace-root`
 
-* Default: false
-* Type: Boolean
+-   Default: false
+-   Type: Boolean
 
 Include the workspace root when workspaces are enabled for a command.
 
@@ -298,10 +297,10 @@ This value is not exported to the environment for child processes.
 
 ### See Also
 
-* [package spec](/cli/v8/using-npm/package-spec)
-* [init-package-json module](http://npm.im/init-package-json)
-* [package.json](/cli/v8/configuring-npm/package-json)
-* [npm version](/cli/v8/commands/npm-version)
-* [npm scope](/cli/v8/using-npm/scope)
-* [npm exec](/cli/v8/commands/npm-exec)
-* [npm workspaces](/cli/v8/using-npm/workspaces)
+-   [package spec](/cli/v8/using-npm/package-spec)
+-   [init-package-json module](http://npm.im/init-package-json)
+-   [package.json](/cli/v8/configuring-npm/package-json)
+-   [npm version](/cli/v8/commands/npm-version)
+-   [npm scope](/cli/v8/using-npm/scope)
+-   [npm exec](/cli/v8/commands/npm-exec)
+-   [npm workspaces](/cli/v8/using-npm/workspaces)

--- a/content/cli/v9/commands/npm-init.md
+++ b/content/cli/v9/commands/npm-init.md
@@ -6,42 +6,42 @@ github_repo: npm/cli
 github_branch: latest
 github_path: docs/lib/content/commands/npm-init.md
 redirect_from:
-  - /cli-commands/init
-  - /cli-commands/npm-init
-  - /cli-documentation/cli-commands/init
-  - /cli-documentation/cli-commands/npm-init
-  - /cli-documentation/commands/init
-  - /cli-documentation/commands/npm-init
-  - /cli-documentation/init
-  - /cli-documentation/npm-init
-  - /cli-documentation/v9/cli-commands/init
-  - /cli-documentation/v9/cli-commands/npm-init
-  - /cli-documentation/v9/commands/init
-  - /cli-documentation/v9/commands/npm-init
-  - /cli-documentation/v9/init
-  - /cli-documentation/v9/npm-init
-  - /cli/cli-commands/init
-  - /cli/cli-commands/npm-init
-  - /cli/commands/init
-  - /cli/commands/npm-init
-  - /cli/init
-  - /cli/npm-init
-  - /cli/v9/cli-commands/init
-  - /cli/v9/cli-commands/npm-init
-  - /cli/v9/commands/init
-  - /cli/v9/init
-  - /cli/v9/npm-init
-  - /commands/init
-  - /commands/npm-init
+    - /cli-commands/init
+    - /cli-commands/npm-init
+    - /cli-documentation/cli-commands/init
+    - /cli-documentation/cli-commands/npm-init
+    - /cli-documentation/commands/init
+    - /cli-documentation/commands/npm-init
+    - /cli-documentation/init
+    - /cli-documentation/npm-init
+    - /cli-documentation/v9/cli-commands/init
+    - /cli-documentation/v9/cli-commands/npm-init
+    - /cli-documentation/v9/commands/init
+    - /cli-documentation/v9/commands/npm-init
+    - /cli-documentation/v9/init
+    - /cli-documentation/v9/npm-init
+    - /cli/cli-commands/init
+    - /cli/cli-commands/npm-init
+    - /cli/commands/init
+    - /cli/commands/npm-init
+    - /cli/init
+    - /cli/npm-init
+    - /cli/v9/cli-commands/init
+    - /cli/v9/cli-commands/npm-init
+    - /cli/v9/commands/init
+    - /cli/v9/init
+    - /cli/v9/npm-init
+    - /commands/init
+    - /commands/npm-init
 ---
 
 ### Synopsis
 
 ```bash
-npm init <package-spec> (same as `npx <package-spec>)
+npm init <package-spec> (same as `npx <package-spec>`)
 npm init <@scope> (same as `npx <@scope>/create`)
 
-aliases: create, innit
+aliases: create, init
 ```
 
 ### Description
@@ -57,11 +57,11 @@ running any other initialization-related operations.
 The init command is transformed to a corresponding `npm exec` operation as
 follows:
 
-* `npm init foo` -> `npm exec create-foo`
-* `npm init @usr/foo` -> `npm exec @usr/create-foo`
-* `npm init @usr` -> `npm exec @usr/create`
-* `npm init @usr@2.0.0` -> `npm exec @usr/create@2.0.0`
-* `npm init @usr/foo@2.0.0` -> `npm exec @usr/create-foo@2.0.0`
+-   `npm init foo` -> `npm exec create-foo`
+-   `npm init @usr/foo` -> `npm exec @usr/create-foo`
+-   `npm init @usr` -> `npm exec @usr/create`
+-   `npm init @usr@2.0.0` -> `npm exec @usr/create@2.0.0`
+-   `npm init @usr/foo@2.0.0` -> `npm exec @usr/create-foo@2.0.0`
 
 If the initializer is omitted (by just calling `npm init`), init will fall
 back to legacy init behavior. It will ask you a bunch of questions, and
@@ -71,14 +71,14 @@ strictly additive, so it will keep any fields and values that were already
 set. You can also use `-y`/`--yes` to skip the questionnaire altogether. If
 you pass `--scope`, it will create a scoped package.
 
-*Note:* if a user already has the `create-<initializer>` package
-globally installed, that will be what `npm init` uses.  If you want npm
+_Note:_ if a user already has the `create-<initializer>` package
+globally installed, that will be what `npm init` uses. If you want npm
 to use the latest version, or another specific version you must specify
 it:
 
-* `npm init foo@latest` # fetches and runs the latest `create-foo` from
+-   `npm init foo@latest` # fetches and runs the latest `create-foo` from
     the registry
-* `npm init foo@1.2.3` #  runs `create-foo@1.2.3` specifically
+-   `npm init foo@1.2.3` # runs `create-foo@1.2.3` specifically
 
 #### Forwarding additional options
 
@@ -89,8 +89,8 @@ To better illustrate how options are forwarded, here's a more evolved
 example showing options passed to both the **npm cli** and a create package,
 both following commands are equivalent:
 
-- `npm init foo -y --registry=<url> -- --hello -a`
-- `npm exec -y --registry=<url> -- create-foo --hello -a`
+-   `npm init foo -y --registry=<url> -- --hello -a`
+-   `npm exec -y --registry=<url> -- create-foo --hello -a`
 
 ### Examples
 
@@ -189,42 +189,42 @@ dot to represent the current directory in that context, e.g: `react-app .`:
 
 #### `yes`
 
-* Default: null
-* Type: null or Boolean
+-   Default: null
+-   Type: null or Boolean
 
 Automatically answer "yes" to any prompts that npm might print on the
 command line.
 
 #### `force`
 
-* Default: false
-* Type: Boolean
+-   Default: false
+-   Type: Boolean
 
 Removes various protections against unfortunate side effects, common
 mistakes, unnecessary performance degradation, and malicious input.
 
-* Allow clobbering non-npm files in global installs.
-* Allow the `npm version` command to work on an unclean git repository.
-* Allow deleting the cache folder with `npm cache clean`.
-* Allow installing packages that have an `engines` declaration requiring a
-  different version of npm.
-* Allow installing packages that have an `engines` declaration requiring a
-  different version of `node`, even if `--engine-strict` is enabled.
-* Allow `npm audit fix` to install modules outside your stated dependency
-  range (including SemVer-major changes).
-* Allow unpublishing all versions of a published package.
-* Allow conflicting peerDependencies to be installed in the root project.
-* Implicitly set `--yes` during `npm init`.
-* Allow clobbering existing values in `npm pkg`
-* Allow unpublishing of entire packages (not just a single version).
+-   Allow clobbering non-npm files in global installs.
+-   Allow the `npm version` command to work on an unclean git repository.
+-   Allow deleting the cache folder with `npm cache clean`.
+-   Allow installing packages that have an `engines` declaration requiring a
+    different version of npm.
+-   Allow installing packages that have an `engines` declaration requiring a
+    different version of `node`, even if `--engine-strict` is enabled.
+-   Allow `npm audit fix` to install modules outside your stated dependency
+    range (including SemVer-major changes).
+-   Allow unpublishing all versions of a published package.
+-   Allow conflicting peerDependencies to be installed in the root project.
+-   Implicitly set `--yes` during `npm init`.
+-   Allow clobbering existing values in `npm pkg`
+-   Allow unpublishing of entire packages (not just a single version).
 
 If you don't have a clear idea of what you want to do, it is strongly
 recommended that you do not use this option!
 
 #### `scope`
 
-* Default: the scope of the current project, if any, or ""
-* Type: String
+-   Default: the scope of the current project, if any, or ""
+-   Type: String
 
 Associate an operation with a scope for a scoped registry.
 
@@ -250,11 +250,10 @@ This will also cause `npm init` to create a scoped package.
 npm init --scope=@foo --yes
 ```
 
-
 #### `workspace`
 
-* Default:
-* Type: String (can be set multiple times)
+-   Default:
+-   Type: String (can be set multiple times)
 
 Enable running a command in the context of the configured workspaces of the
 current project while filtering by running only the workspaces defined by
@@ -262,10 +261,10 @@ this configuration option.
 
 Valid values for the `workspace` config are either:
 
-* Workspace names
-* Path to a workspace directory
-* Path to a parent workspace directory (will result in selecting all
-  workspaces within that folder)
+-   Workspace names
+-   Path to a workspace directory
+-   Path to a parent workspace directory (will result in selecting all
+    workspaces within that folder)
 
 When set for the `npm init` command, this may be set to the folder of a
 workspace which does not yet exist, to create the folder and set it up as a
@@ -275,8 +274,8 @@ This value is not exported to the environment for child processes.
 
 #### `workspaces`
 
-* Default: null
-* Type: null or Boolean
+-   Default: null
+-   Type: null or Boolean
 
 Set to true to run the command in the context of **all** configured
 workspaces.
@@ -284,25 +283,25 @@ workspaces.
 Explicitly setting this to false will cause commands like `install` to
 ignore workspaces altogether. When not set explicitly:
 
-- Commands that operate on the `node_modules` tree (install, update, etc.)
-will link workspaces into the `node_modules` folder. - Commands that do
-other things (test, exec, publish, etc.) will operate on the root project,
-_unless_ one or more workspaces are specified in the `workspace` config.
+-   Commands that operate on the `node_modules` tree (install, update, etc.)
+    will link workspaces into the `node_modules` folder. - Commands that do
+    other things (test, exec, publish, etc.) will operate on the root project,
+    _unless_ one or more workspaces are specified in the `workspace` config.
 
 This value is not exported to the environment for child processes.
 
 #### `workspaces-update`
 
-* Default: true
-* Type: Boolean
+-   Default: true
+-   Type: Boolean
 
 If set to true, the npm cli will run an update after operations that may
 possibly change the workspaces installed to the `node_modules` folder.
 
 #### `include-workspace-root`
 
-* Default: false
-* Type: Boolean
+-   Default: false
+-   Type: Boolean
 
 Include the workspace root when workspaces are enabled for a command.
 
@@ -314,10 +313,10 @@ This value is not exported to the environment for child processes.
 
 ### See Also
 
-* [package spec](/cli/v9/using-npm/package-spec)
-* [init-package-json module](http://npm.im/init-package-json)
-* [package.json](/cli/v9/configuring-npm/package-json)
-* [npm version](/cli/v9/commands/npm-version)
-* [npm scope](/cli/v9/using-npm/scope)
-* [npm exec](/cli/v9/commands/npm-exec)
-* [npm workspaces](/cli/v9/using-npm/workspaces)
+-   [package spec](/cli/v9/using-npm/package-spec)
+-   [init-package-json module](http://npm.im/init-package-json)
+-   [package.json](/cli/v9/configuring-npm/package-json)
+-   [npm version](/cli/v9/commands/npm-version)
+-   [npm scope](/cli/v9/using-npm/scope)
+-   [npm exec](/cli/v9/commands/npm-exec)
+-   [npm workspaces](/cli/v9/using-npm/workspaces)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Resolving the issue #5837 for repo  :
https://github.com/npm/[cli] (https://github.com/npm/cli)

Missing backticks on "npm init <package-spec> (same as `npx <package-spec>)" line 25 for both files (v8 and v9)

Despite what it said on CONTRIBUTION.md, this issue can't be done on npm/cli cause of autogenerated code.

Hope I did well, do not hesitate to tell me if i did wrong.
I'll ask to close the associated issu if it's good for you.


## References

content/cli/v8/commands/npm-init.md
content/cli/v9/commands/npm-init.md
Line 25 added missing backticks
Line 28 "innit" -> "init"

