### PR TITLE
docs: fix dangling/broken link

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-private-packages.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-private-packages.mdx
@@ -108,3 +108,4 @@ For more information on the `publish` command, see the [CLI documentation][cli-p
 [developers]: /misc/developers#keeping-files-out-of-your-package
 [cli-publish]: /cli/publish
 [reg-config]: configuring-your-registry-settings-as-an-npm-enterprise-user#using-npmrc-to-manage-multiple-profiles-for-different-registries
+[pii]: https://en.wikipedia.org/wiki/Personally_identifiable_information


### PR DESCRIPTION
Link to https://en.wikipedia.org/wiki/Personally_identifiable_information was not provided so [the text](https://docs.npmjs.com/creating-and-publishing-private-packages#reviewing-package-contents-for-sensitive-or-unnecessary-information) was not rendering as a link:

![image](https://user-images.githubusercontent.com/20465797/210682194-423db39a-0542-46b3-914e-dfe4f4ee7729.png)
