### PR TITLE
docs: update link to trademark policy

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/package-name-guidelines.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/package-name-guidelines.mdx
@@ -16,5 +16,5 @@ Additionally, when choosing a name for an [**unscoped** package][create-unscoped
 
 
 [policies]: https://www.npmjs.com/policies
-[npm-trademark]: https://www.npmjs.com/policies/trademark#the-npm-trademark-policy
+[npm-trademark]: https://docs.npmjs.com/policies/disputes#trademarks
 [create-unscoped]: creating-and-publishing-unscoped-public-packages


### PR DESCRIPTION
On the [package name guidelines page](https://docs.npmjs.com/package-name-guidelines) the current link to the trademark policy https://www.npmjs.com/policies/trademark#the-npm-trademark-policy is dead (I get 404 response page). I have updated it to point to the trademark section of the disputes page here https://docs.npmjs.com/policies/disputes#trademarks (hopefully this is acceptable).

PS: apologies for the many doc fix PRs - I am fixing issues as I encounter them while reviewing the entire docs.npmjs.com site. I am almost done, so there won't be too many more PRs :pray: 