### PR TITLE
docs: fix typo on "adding collaborators" page

### DIFF
--- a/content/packages-and-modules/updating-and-managing-your-published-packages/adding-collaborators-to-private-packages-owned-by-a-user-account.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/adding-collaborators-to-private-packages-owned-by-a-user-account.mdx
@@ -10,7 +10,7 @@ As an npm user with a paid user account, you can add another npm user with a pai
 
 </Note>
 
-When you add a member to your package, they are sent an email inviting them to the package. The new member has to accept the invitation gain access to the package.
+When you add a member to your package, they are sent an email inviting them to the package. The new member has to accept the invitation to gain access to the package.
 
 ## Granting access to a private user package on the web
 


### PR DESCRIPTION
This:

> ...the invitation **gain** access...

Should be:

> ...the invitation **to** gain access...