### PR TITLE
docs: fix broken link

### DIFF
--- a/content/packages-and-modules/securing-your-code/requiring-2fa-for-package-publishing-and-settings-modification.mdx
+++ b/content/packages-and-modules/securing-your-code/requiring-2fa-for-package-publishing-and-settings-modification.mdx
@@ -5,7 +5,7 @@ import shared from '../../../src/shared.js'
 
 To protect your packages, as a package publisher, you can require everyone who has write access to a package to have two-factor authentication (2FA) enabled. This will require that users provide 2FA credentials in addition to their login token when they publish the package. For more information, see "[Configuring two-factor authentication][config-2fa]".
 
-You may also choose to allow publishing with either two-factor authentication _or_ with [automation tokens][creating-tokens]. This lets you configure automation tokens in a CI/CD workflow, but requires two-factor authentication from interactive publishes.
+You may also choose to allow publishing with either two-factor authentication _or_ with [automation tokens][creating-automation-token]. This lets you configure automation tokens in a CI/CD workflow, but requires two-factor authentication from interactive publishes.
 
 ## Configuring two-factor authentication
 
@@ -24,7 +24,7 @@ You may also choose to allow publishing with either two-factor authentication _o
       With this option, a maintainer can publish a package or change the package settings whether they have two-factor authentication enabled or not. This is the least secure setting.
 
    2. **Require two-factor authentication or automation tokens or granular access token**  
-      With this option, maintainers must have two-factor authentication enabled for their account.  If they publish a package interactively, using the `npm publish` command, they will be required to enter 2FA credentials when they perform the publish. However, maintainers may also create an [automation token][creating-automation-token] or a [granular access token][creating-granular-access-token]and use that to publish. A second factor is _not_ required when using a token, making it useful for continuous integration and continuous deployment workflows.
+      With this option, maintainers must have two-factor authentication enabled for their account.  If they publish a package interactively, using the `npm publish` command, they will be required to enter 2FA credentials when they perform the publish. However, maintainers may also create an [automation token][creating-automation-token] or a [granular access token][creating-granular-access-token] and use that to publish. A second factor is _not_ required when using a token, making it useful for continuous integration and continuous deployment workflows.
 
    3. **Require two-factor authentication and disallow tokens**  
       With this option, a maintainer must have two-factor authentication enabled for their account, and they must publish interactively. Maintainers will be required to enter 2FA credentials when they perform the publish. Automation tokens and granular access tokens cannot be used to publish packages.


### PR DESCRIPTION
The link to [Creating and viewing access tokens](https://docs.npmjs.com/creating-and-viewing-access-tokens) was not correctly defined and is not rendering correctly on [the live site](https://docs.npmjs.com/requiring-2fa-for-package-publishing-and-settings-modification):

![image](https://user-images.githubusercontent.com/20465797/211696220-a8dd73a7-8464-47f1-a306-7f6d693747b4.png)


