### PR TITLE
docs: fix broken links on access tokens page

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/creating-and-viewing-access-tokens.mdx
+++ b/content/integrations/integrating-npm-with-external-services/creating-and-viewing-access-tokens.mdx
@@ -89,7 +89,7 @@ You can create tokens with **read-only** permissions or **read and publish** per
 
 <Note>
 
-**Note:** You cannot create legacy automation tokens or granular access tokens from the CLI. You must use the website to generate these types of tokens. For more information, see "[Creating legacy tokens on the website][creating-legacy-tokens-on-the-website]" and "[Creating granular access tokens on the website][creating-granular-access-tokens-on-the-website]."
+**Note:** You cannot create legacy automation tokens or granular access tokens from the CLI. You must use the website to generate these types of tokens. For more information, see "[Creating legacy tokens on the website](#creating-legacy-tokens-on-the-website)" and "[Creating granular access tokens on the website](#creating-granular-access-tokens-on-the-website)."
 
 </Note> 
 


### PR DESCRIPTION
The broken links appear to target sections of the same page but were not specified correctly in the markdown syntax, so they render incorrectly on the [live site](https://docs.npmjs.com/creating-and-viewing-access-tokens):

![image](https://user-images.githubusercontent.com/20465797/211700412-bba71538-6da3-4b45-8c96-c20f74bb6f58.png)