### PR TITLE
doc: remove reference to lastpass

### DIFF
--- a/content/getting-started/setting-up-your-npm-user-account/creating-a-strong-password.mdx
+++ b/content/getting-started/setting-up-your-npm-user-account/creating-a-strong-password.mdx
@@ -12,7 +12,7 @@ You must choose or generate a password for your npm account that:
 
 To keep your account secure, we recommend you follow these best practices:
 
-* Use a password manager, such as [LastPass](https://lastpass.com/) or [1Password](https://1password.com/), to generate a password more than 16 characters.
+* Use a password manager, such as [1Password](https://1password.com/), to generate a password more than 16 characters.
 * Generate a unique password for npm. If you use your npm password elsewhere and that service is compromised, then attackers or other malicious actors could use that information to access your npm account.
 * Configure two-factor authentication for your account. For more information, see "About two-factor authentication."
 * Never share your password, even with a potential collaborator. Each person should use their own personal account on npm. For more information on ways to collaborate, see: "[npm organizations](/organizations)".


### PR DESCRIPTION
based on the [recent security incident](https://blog.lastpass.com/2022/12/notice-of-recent-security-incident/) I don't think we should still be recommending lastpass