### PR TITLE
Fix typo

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/downloading-and-installing-packages-locally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/downloading-and-installing-packages-locally.mdx
@@ -25,7 +25,7 @@ If there is a `package.json` file, npm installs the latest version that satisfie
 
 </Note>
 
-## Installed a scoped public package
+## Installing a scoped public package
 
 [Scoped public packages][scoped-public-pkg] can be downloaded and installed by anyone, as long as the scope name is referenced during installation:
 


### PR DESCRIPTION
Fix typo on line 28,
`## Installed a` -> `## Installing a`

<!-- What / Why -->
Fix typo on line 28, to let readers focus on the content rather than the typo (Installed -> Installing)

<!-- Describe the request in detail. What it does and why it's being changed. -->
The request makes changes on the word `Installed` to `Installing`. It makes a grammatical fix to the documentation for other users to read. This is to make readers focus on the content rather than the typo

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
