### PR TITLE
Update default branch name from master to main

### DIFF
--- a/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
+++ b/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
@@ -37,7 +37,7 @@ Git URLs used for npm packages can be formatted in the following ways:
 - `git+https://user@hostname/project/blah.git#commit-ish`
 
 The `commit-ish` can be any tag, sha, or branch that can be supplied as
-an argument to `git checkout`. The default `commit-ish` is `master`.
+an argument to `git checkout`. The default `commit-ish` is `main`.
 
 ## About modules
 

--- a/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
+++ b/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
@@ -37,7 +37,7 @@ Git URLs used for npm packages can be formatted in the following ways:
 - `git+https://user@hostname/project/blah.git#commit-ish`
 
 The `commit-ish` can be any tag, sha, or branch that can be supplied as
-an argument to `git checkout`. The default `commit-ish` is `main`.
+an argument to `git checkout`. The default `commit-ish` is `HEAD`.
 
 ## About modules
 


### PR DESCRIPTION
This proposed PR updates a reference to the default branch name from `master` to `main`.

Reference: https://github.com/github/renaming

