### PR TITLE
Fix typo in provenance GitHub Actions workflow snippet

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -48,7 +48,7 @@ To update your GitHub Actions workflow to publish your packages with provenance,
 - Give permission to mint an ID-token:
   
   ```
-  permission:
+  permissions:
     id-token: write
   ```
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Fix a typo in provenance GitHub Actions workflow snippet. The key must be exactly "permissions" (not "permission"). The full example workflow below this snippet uses the correct key.

The final line change was inserted automatically by the GitHub editor (:sweat:), let me know if I should remove it.

## References

Relates to 90fadd9fac8b8b1ee78d7a8b68f0461d64a76d47

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
