### PR TITLE
doc: missing npm run build step

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -81,6 +81,7 @@ jobs:
          registry-url: 'https://registry.npmjs.org'
      - run: npm install -g npm
      - run: npm ci
+     - run: npm run build
      - run: npm publish --provenance --access public
        env:
          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- What / Why -->

I copied the snippet provided to create a GitHub action and used it to publish to npm.
As `npm run build` is missing in the action, I ended publishing an empty package to npmjs.


