### PR TITLE
Fix id-token permissions doc in generating-provenance-statements.mdx

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -48,7 +48,7 @@ To update your GitHub Actions workflow to publish your packages with provenance,
 - Give permission to mint an ID-token:
   
   ```
-  permission:
+  permissions:
     id-token: write
   ```
 


### PR DESCRIPTION
Ref: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

The example bellow is correct. GHA docs use the plural.

## References
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs