### PR TITLE
update wording in semantic versioning example

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/about-semantic-versioning.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/about-semantic-versioning.mdx
@@ -27,7 +27,7 @@ To help developers who rely on your code, we recommend starting your package ver
 
 You can specify which update types your package can accept from dependencies in your package's `package.json` file.
 
-For example, to specify acceptable version ranges up to 1.0.4, use the following syntax:
+For example, to specify an accepted version range of 1.0.4 and up, use the following syntax:
 
 * Patch releases: `1.0` or `1.0.x` or `~1.0.4`
 * Minor releases: `1` or `1.x` or `^1.0.4`


### PR DESCRIPTION
the wording "up to 1.0.4" communicates the opposite of what the immediately following examples specify, namely: patch, minor or major versions following 1.0.4
