### PR TITLE
Added clarification about .npmrc and setup-node

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/using-private-packages-in-a-ci-cd-workflow.mdx
+++ b/content/integrations/integrating-npm-with-external-services/using-private-packages-in-a-ci-cd-workflow.mdx
@@ -71,6 +71,8 @@ Consult your CI/CD server's documentation for more details.
 
 ## Create and check in a project-specific .npmrc file
 
+**NOTICE:** This **DO NOT** work if you use `setup-node` action in Github Actions because it creates the `.npmrc` file automatically. Instead, see https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs#example-using-a-private-registry-and-creating-the-npmrc-file to configure it correctly.
+
 Use a project-specific `.npmrc` file with a variable for your token to securely authenticate your CI/CD server with npm.
 
 1. In the root directory of your project, create a custom `.npmrc` file with the following contents:


### PR DESCRIPTION
Project-specific `.npmrc` file does not work if Github Actions' `setup-node` is used. Though this is more GA related thing, I think it would be good to mention about it in NPM's documentation also.