### PR TITLE
Update creating-and-publishing-scoped-public-packages.mdx

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-scoped-public-packages.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-scoped-public-packages.mdx
@@ -101,7 +101,7 @@ By default, scoped packages are published with private visibility. To publish a 
 For more information on the `publish` command, see the [CLI documentation][cli-publish].
 
 
-[scopes]: about-scopes
+[scopes]: https://docs.npmjs.com/about-scopes
 [user-signup]: https://www.npmjs.com/signup
 [create-org]: https://www.npmjs.com/signup?next=/org/create
 [reg-config]: configuring-your-registry-settings-as-an-npm-enterprise-user


### PR DESCRIPTION
The link to "about scopes" was broken, going to `https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/about-scopes` instead of `https://docs.npmjs.com/about-scopes/`.
