### PR TITLE
Fixed typo

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/using-npm-packages-in-your-projects.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/using-npm-packages-in-your-projects.mdx
@@ -39,7 +39,7 @@ To use a scoped package, simply include the scope wherever you use the package n
 
 
 ```js
-var projectName = require("@scope/package-name")
+var projectName = require("@scope/package-name");
 ```
 
 ### package.json file


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fixed typo on line 42
```js
var projectName = require("@scope/package-name") /*No semicolon*/ 

var projectName = require("@scope/package-name");  /*Added semicolon*/ 
```
Fixed typo on line 42 by adding a semi-colon after the variable assignment that would cause a syntax error since it is used to separate different statements in JavaScript.

The request makes changes on the syntax by adding a semi colon after the projectName variable. It makes a syntax fix to the documentation for other users hence not getting some unexpected errors when the code is copied.
