### PR TITLE
docs: fix typos

### DIFF
--- a/content/cli/v8/commands/npm-version.md
+++ b/content/cli/v8/commands/npm-version.md
@@ -24,7 +24,7 @@ redirect_from:
 ```bash
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
 
-alias: verison
+alias: version
 ```
 
 ### Configuration

--- a/content/cli/v8/using-npm/dependency-selectors.md
+++ b/content/cli/v8/using-npm/dependency-selectors.md
@@ -13,7 +13,7 @@ redirect_from:
 
 ### Description
 
-The [`npm query`](/cli/v8/commands/npm-query) commmand exposes a new dependency selector syntax (informed by & respecting many aspects of the [CSS Selectors 4 Spec](https://dev.w3.org/csswg/selectors4/#relational)) which:
+The [`npm query`](/cli/v8/commands/npm-query) command exposes a new dependency selector syntax (informed by & respecting many aspects of the [CSS Selectors 4 Spec](https://dev.w3.org/csswg/selectors4/#relational)) which:
 
 - Standardizes the shape of, & querying of, dependency graphs with a robust object model, metadata & selector syntax
 - Leverages existing, known language syntax & operators from CSS to make disparate package information broadly accessible

--- a/content/cli/v8/using-npm/scripts.md
+++ b/content/cli/v8/using-npm/scripts.md
@@ -231,8 +231,8 @@ While npm v6 had `uninstall` lifecycle scripts, npm v7 does not. Removal of a pa
 Reasons for a package removal include:
 
 * a user directly uninstalled this package
-* a user uninstalled a dependant package and so this dependency is being uninstalled
-* a user uninstalled a dependant package but another package also depends on this version
+* a user uninstalled a dependent package and so this dependency is being uninstalled
+* a user uninstalled a dependent package but another package also depends on this version
 * this version has been merged as a duplicate with another version
 * etc.
 

--- a/content/cli/v9/commands/npm-version.md
+++ b/content/cli/v9/commands/npm-version.md
@@ -40,7 +40,7 @@ redirect_from:
 ```bash
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
 
-alias: verison
+alias: version
 ```
 
 ### Configuration

--- a/content/cli/v9/using-npm/scripts.md
+++ b/content/cli/v9/using-npm/scripts.md
@@ -235,8 +235,8 @@ While npm v6 had `uninstall` lifecycle scripts, npm v7 does not. Removal of a pa
 Reasons for a package removal include:
 
 * a user directly uninstalled this package
-* a user uninstalled a dependant package and so this dependency is being uninstalled
-* a user uninstalled a dependant package but another package also depends on this version
+* a user uninstalled a dependent package and so this dependency is being uninstalled
+* a user uninstalled a dependent package but another package also depends on this version
 * this version has been merged as a duplicate with another version
 * etc.
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `content/cli/v8/commands/npm-version.md`
1 typo in `content/cli/v8/using-npm/dependency-selectors.md`
2 typos in `content/cli/v8/using-npm/scripts.md`
1 typo in `content/cli/v9/commands/npm-version.md`
2 typos in `content/cli/v9/using-npm/scripts.md`


Best!