### PR TITLE
Add GitLab CI to the list of supported CI providers for provenance

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -26,7 +26,7 @@ The transparency log service provides a public, verifiable, tamper-evident ledge
 
 ## Provenance limitations
 
-- In order to publish a package with provenance, you must build your package with a supported cloud CI/CD provider using a cloud-hosted runner from a public source repository. Today this includes GitHub Actions, and we are collaborating with additional providers to expand support. For more information on how to establish provenance using GitHub Actions, see "[Publishing packages with provenance via GitHub Actions][publishing-with-provenance]."
+- In order to publish a package with provenance, you must build your package with a supported cloud CI/CD provider using a cloud-hosted runner from a public source repository. Today this includes GitHub Actions and GitLab CI, and we are collaborating with additional providers to expand support. For more information on how to establish provenance using GitHub Actions, see "[Publishing packages with provenance via GitHub Actions][publishing-with-provenance]."
 - When a package in the npm registry has established provenance, it does not guarantee the package has no malicious code. Instead, npm provenance provides a verifiable link to the package's source code and build instructions, which developers can then audit and determine whether to trust it or not. For more information, see "[Searching for and choosing packages to download][provenance-info]."
 
 ## Prerequisites


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

https://github.com/npm/cli/pull/6375 and https://github.com/npm/documentation/pull/684 highlight that GitHub Actions is no longer the only supported provider. we currently link from our semantic-release docs for configuring GitHub Actions, and I would like to do similar for GitLab CI
