### PR TITLE
Fix typo in generating-provenance-statements.mdx

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -114,7 +114,7 @@ publish:
       aud: sigstore
   script:
     - npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-    - npm publish --provenance --access publich
+    - npm publish --provenance --access public
 ```
 
 ### Using third-party package publishing tools


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

`publich` should instead read `public` in the GitLab provenance example.