### PR TITLE
added an aria-label for the search input field

### DIFF
--- a/theme/src/components/search.js
+++ b/theme/src/components/search.js
@@ -14,6 +14,7 @@ function Search(props) {
         {...getInputProps({
           placeholder: `Search ${siteMetadata.title}`,
           width: 240,
+          'aria-label': `Search ${siteMetadata.title}`
         })}
       />
       <Position


### PR DESCRIPTION
Label/title is not defined for "Search npm Docs" edit field.

aria-label is added for the search input field.


## References
  Fixes #5930
  Fixes url: https://github.com/github/accessibility-audits/issues/5930
  
  Screen Record for the fix:
  [https://github-grid.enterprise.slack.com/files/U05R2JD2H8S/F061LH9FCJU/screenshare_-_2023-10-12_2_28_31_pm.webm](url)
