### PR TITLE
Bugfix 5931: Scrollable content is not accessible on npm docs pages

### DIFF
--- a/theme/src/layout/index.js
+++ b/theme/src/layout/index.js
@@ -1,6 +1,6 @@
 import {BorderBox, Box, Flex, Grid, Heading, Position, StyledOcticon, Text} from '@primer/components'
 import {ChevronDownIcon, ChevronRightIcon} from '@primer/octicons-react'
-import React from 'react'
+import React, {useEffect} from 'react'
 import Head from '../components/head'
 import Header, {HEADER_HEIGHT} from '../components/header'
 import PageFooter from '../components/page-footer'
@@ -12,11 +12,16 @@ import VariantSelect from '../components/variant-select'
 import NavHierarchy from '../util/nav-hierarchy'
 import Details from '../components/details'
 import * as Slugger from '../hooks/use-slugger'
+import {makePreElementsFocusable} from '../util/common'
 
 function Layout({children, pageContext, location}) {
   const {title, description, status, source} = pageContext.frontmatter
 
   const variantRoot = NavHierarchy.getVariantRoot(location.pathname)
+
+  useEffect(() => {
+    makePreElementsFocusable()
+  }, [children])
 
   return (
     <Slugger.Provider>

--- a/theme/src/util/common.js
+++ b/theme/src/util/common.js
@@ -1,0 +1,8 @@
+
+export function makePreElementsFocusable() {
+    const preElements = document.getElementsByTagName('pre')
+    const preElementsList = Array.prototype.slice.call(preElements)
+    for (const pre of preElementsList) {
+      pre.setAttribute('tabindex', 0)
+    }
+  }


### PR DESCRIPTION
Ref: https://github.com/github/accessibility-audits/issues/5931

Scrollable content (HTML \<pre\> elements) are not getting focussed while using keyboard tab key to navigate the pages.

Fix is to add the tabIndex property with value 0 for all those elements.