### PR TITLE
Bugfix 5931 scrollable content accessibility

### DIFF
--- a/theme/src/components/code.js
+++ b/theme/src/components/code.js
@@ -52,7 +52,7 @@ function Code({className, children}) {
       </div>
       <Highlight {...defaultProps} code={code} language={language} theme={githubTheme}>
         {({className, style, tokens, getLineProps, getTokenProps}) => (
-          <BorderBox as="pre" className={className} mt={0} mb={3} p={3} border={0} style={{...style, overflow: 'auto'}}>
+          <BorderBox tabIndex={0} as="pre" className={className} mt={0} mb={3} p={3} border={0} style={{...style, overflow: 'auto'}}>
             {/* This is the scroll handle, it is supposed to be focused with keyboard and scroll a wide codebox horizontally */}
             <div aria-hidden="true" style={{visibility: 'hidden', position: 'absolute', ...size}} ref={scrollRef} />
             {tokens.map((line, i) => (


### PR DESCRIPTION
Ref: https://github.com/github/accessibility-audits/issues/5931

Scrollable content (HTML \<pre\> elements) are not getting focussed while using keyboard tab key to navigate the pages.

Fix is to add the tabIndex property with value 0 for all those elements.