### PR TITLE
Bugfix 6054 aria labelledby select version

### DIFF
--- a/theme/src/components/variant-select.js
+++ b/theme/src/components/variant-select.js
@@ -59,7 +59,7 @@ function VariantSelect(props) {
 
   return (
     <ThemeProvider>
-      <p id="label-versions-list-item" htmlFor="versions-list-item">
+      <p id="label-versions-list-item">
         Select CLI Version:
       </p>
       <ActionMenu open={open} onOpenChange={setOpen}>

--- a/theme/src/components/variant-select.js
+++ b/theme/src/components/variant-select.js
@@ -55,22 +55,22 @@ function VariantSelect(props) {
     )
   }
 
-  const ariaLabelMenuButton = open ? 'Version release' : selectedItem.variant.title
+  // const ariaLabelMenuButton = open ? 'Version release' : selectedItem.variant.title
 
   return (
     <ThemeProvider>
-      <label id="label-versions-list-item" htmlFor="versions-list-item">
+      <p id="label-versions-list-item" htmlFor="versions-list-item">
         Select CLI Version:
-      </label>
+      </p>
       <ActionMenu open={open} onOpenChange={setOpen}>
         {/* Disabling to remove lint warnings. This property was added as "autofocus"
         in a previous accessibility audit which did not trigger the lint warning. */
         /* eslint-disable-next-line jsx-a11y/no-autofocus */}
-        <ActionMenu.Button autoFocus aria-label={ariaLabelMenuButton}>
+        <ActionMenu.Button autoFocus aria-labelledby="label-versions-list-item">
           {selectedItem.variant.title}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium" onEscape={() => setOpen(false)}>
-          <ActionList id="versions-list-item" aria-labelledby="label-versions-list-item">
+          <ActionList id="versions-list-item">
             {items}
           </ActionList>
         </ActionMenu.Overlay>


### PR DESCRIPTION
1. `label` tag is replaced with `p` tag for removing `htmlFor`
2. `aria-label` is replaced with `aria-labelledby` for reading screen reader
3. removed unwanted `aria-labelledby`
4. commented unwanted `const`

expected result: Screen reader is now announcing the associated label.

References
Fixes #6054
Fixes url: https://github.com/github/accessibility-audits/issues/6054

Screen record is attached

https://github.com/npm/documentation/assets/141764922/ff12e2fe-9908-4084-a350-aeaf69fca86a

