### PR TITLE
[5940] and [5936] show table of contents when browser window gets small

### DIFF
--- a/theme/src/layout/index.js
+++ b/theme/src/layout/index.js
@@ -1,5 +1,4 @@
-import {BorderBox, Box, Flex, Grid, Heading, Position, StyledOcticon, Text} from '@primer/components'
-import {ChevronDownIcon, ChevronRightIcon} from '@primer/octicons-react'
+import {BorderBox, Box, Flex, Grid, Heading, Position, Text} from '@primer/components'
 import React from 'react'
 import Head from '../components/head'
 import Header, {HEADER_HEIGHT} from '../components/header'
@@ -10,7 +9,6 @@ import StatusLabel from '../components/status-label'
 import TableOfContents from '../components/table-of-contents'
 import VariantSelect from '../components/variant-select'
 import NavHierarchy from '../util/nav-hierarchy'
-import Details from '../components/details'
 import * as Slugger from '../hooks/use-slugger'
 
 function Layout({children, pageContext, location}) {
@@ -88,23 +86,12 @@ function Layout({children, pageContext, location}) {
               ) : null}
               {pageContext.tableOfContents ? (
                 <Box display={['block', null, 'none']} mb={3}>
-                  <Details>
-                    {({open}) => (
-                      <>
-                        <Text as="summary" fontWeight="bold">
-                          {open ? (
-                            <StyledOcticon icon={ChevronDownIcon} mr={2} />
-                          ) : (
-                            <StyledOcticon icon={ChevronRightIcon} mr={2} />
-                          )}
-                          Table of contents
-                        </Text>
-                        <Box pt={1}>
-                          <TableOfContents items={pageContext.tableOfContents} />
-                        </Box>
-                      </>
-                    )}
-                  </Details>
+                  <>
+                    <Text display="inline-block" fontWeight="bold" mb={1} id="table-of-content-label">
+                      Table of contents
+                    </Text>
+                    <TableOfContents items={pageContext.tableOfContents} labelId="table-of-content-label" />
+                  </>
                 </Box>
               ) : null}
               {children}


### PR DESCRIPTION
https://github.com/github/accessibility-audits/issues/5940
https://github.com/github/accessibility-audits/issues/5936

show table of contents when browser window gets small

closes #5940 and #5936

Same fix for both. Yes it is reproducible that the controls under Table of Contents is not visible in a small screen (only the title is visible "Table of Contents" - and it has to be clicked to see the list. The mouse does not indicate that the title is clickable). I made the the entire Table of Contents block visible (not collapsed) as it seems to be asking for. If not, it just needs the "Pointer" hand cursor for "Table of Contents" (maybe tabindex="0").

![UnderTOC](https://github.com/npm/documentation/assets/141774364/5d6a216e-28a2-4e85-a89f-369f0a114d78)
