### PR TITLE
[5940] TOC has cursor pointer - clickable dropdown

### DIFF
--- a/theme/src/layout/index.js
+++ b/theme/src/layout/index.js
@@ -91,7 +91,7 @@ function Layout({children, pageContext, location}) {
                   <Details>
                     {({open}) => (
                       <>
-                        <Text as="summary" fontWeight="bold">
+                        <Text as="summary" fontWeight="bold" sx={{cursor: 'pointer'}}>
                           {open ? (
                             <StyledOcticon icon={ChevronDownIcon} mr={2} />
                           ) : (


### PR DESCRIPTION
When window gets small, "Table of Contents" becomes a closed dropdown. This fix adds the cursor pointer to "Table of Contents" so that the mouse hover shows it as clickable.
