### PR TITLE
Bugfix for Issue#5934

### DIFF
--- a/theme/src/wrap/root-element.js
+++ b/theme/src/wrap/root-element.js
@@ -24,7 +24,7 @@ function UnderlinedLink(props) {
 }
 
 const components = {
-  a: Link,
+  a: UnderlinedLink,
   pre: props => props.children,
   code: Code,
   inlineCode: InlineCode,

--- a/theme/src/wrap/root-element.js
+++ b/theme/src/wrap/root-element.js
@@ -19,6 +19,10 @@ import Prompt from '../components/prompt'
 import PromptReply from '../components/prompt-reply'
 import Screenshot from '../components/screenshot'
 
+function UnderlinedLink(props) {
+  return <Link {...props} underline={true}/>
+}
+
 const components = {
   a: Link,
   pre: props => props.children,
@@ -43,7 +47,7 @@ const components = {
   Prompt,
   PromptReply,
   Screenshot,
-  Link,
+  Link: UnderlinedLink,
 }
 
 function wrapRootElement({element}) {


### PR DESCRIPTION
Ref:  https://github.com/github/accessibility-audits/issues/5934
Adding a global style so that anchor elements inside text get underline by default. 