### PR TITLE
aria-describedby is using instead labelledby

### DIFF
--- a/theme/src/components/variant-select.js
+++ b/theme/src/components/variant-select.js
@@ -66,11 +66,11 @@ function VariantSelect(props) {
         {/* Disabling to remove lint warnings. This property was added as "autofocus"
         in a previous accessibility audit which did not trigger the lint warning. */
         /* eslint-disable-next-line jsx-a11y/no-autofocus */}
-        <ActionMenu.Button autoFocus aria-labelledby="label-versions-list-item">
+        <ActionMenu.Button autoFocus aria-describedby="label-versions-list-item">
           {selectedItem.variant.title}
         </ActionMenu.Button>
         <ActionMenu.Overlay width="medium" onEscape={() => setOpen(false)}>
-          <ActionList id="versions-list-item">
+          <ActionList id="versions-list-item" aria-labelledby="label-versions-list-item">
             {items}
           </ActionList>
         </ActionMenu.Overlay>


### PR DESCRIPTION
1. added `aria-describedby` for the button
2. reverted the change `aria-labelledby` for the item 

expected result: Screen reader is now announcing the associated label.
Screen shot attached
<img width="400" alt="Screenshot 2023-10-19 at 11 34 20 AM" src="https://github.com/npm/documentation/assets/141764922/e6747fb8-6d12-49cf-ba16-f03f97f0357e">

References
Fixes #6054
Fixes url: https://github.com/github/accessibility-audits/issues/6054