### PR TITLE
Fix broken images

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/searching-for-and-choosing-packages-to-download.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/searching-for-and-choosing-packages-to-download.mdx
@@ -53,7 +53,7 @@ To view provenance information for a package in the npm registry:
 
 2. On the package's page, in the **Version** field to the right of the README, look for a green check mark. If there is a green check mark, this means the package was published with provenance.
 
-   <Screenshot src="packages-and-modules/getting-packages-from-the-registry/npm-provenance-check-mark.png" alt="Screenshot showing a Version field with a green check mark" />
+   <Screenshot src="/packages-and-modules/getting-packages-from-the-registry/npm-provenance-check-mark.png" alt="Screenshot showing a Version field with a green check mark" />
 
 3. Click on the check mark, then click **View more details**.
 
@@ -65,13 +65,13 @@ To view provenance information for a package in the npm registry:
    - **Build File**: A link to the workflow file used to build the package.
    - **Public Ledger**: A link to a transparency log entry attesting an authorized user published the package.
 
-   <Screenshot src="packages-and-modules/getting-packages-from-the-registry/npm-provenance.png" alt="Screenshot showing npm provenance information for a published package" />
+   <Screenshot src="/packages-and-modules/getting-packages-from-the-registry/npm-provenance.png" alt="Screenshot showing npm provenance information for a published package" />
 
 <Note>
 
 **Note:** Whenever you access a package's provenance information on npmjs.com, the linked source commit and repository are checked by npm. If the linked source commit or repository cannot be found, an error message will appear at the top of the page and alongside the provenance information. This is to inform you that the provenance for this package can no longer be established, which may occur when a repository is deleted or made private.
 
-<Screenshot src="packages-and-modules/getting-packages-from-the-registry/npm-provenance-unreachable-source-commit@2x.png" alt="Screenshot showing a warning when the provenance source commit or repository cannot be found." />
+<Screenshot src="/packages-and-modules/getting-packages-from-the-registry/npm-provenance-unreachable-source-commit@2x.png" alt="Screenshot showing a warning when the provenance source commit or repository cannot be found." />
 
 </Note>
 

--- a/content/packages-and-modules/updating-and-managing-your-published-packages/deprecating-and-undeprecating-packages-or-package-versions.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/deprecating-and-undeprecating-packages-or-package-versions.mdx
@@ -40,7 +40,7 @@ Deprecating a package is an alternative to deleting a package if your package do
 
 5. If you are sure that you want to continue, enter your package name and click <strong>Deprecate package</strong>.
 
-   <Screenshot src="packages-and-modules/deleting-deprecating/deprecate-package-confirm.png" alt="Screenshot showing the deprecate package confirmation" />
+   <Screenshot src="/packages-and-modules/deleting-deprecating/deprecate-package-confirm.png" alt="Screenshot showing the deprecate package confirmation" />
 
 ### Using the command line
 


### PR DESCRIPTION
Changes Screenshot path from a relative (broken) URL to an absolute URL, inline with all the other screenshot paths. Fixes PROD bug visible at https://docs.npmjs.com/searching-for-and-choosing-packages-to-download

<img width="890" alt="Screenshot showing images loading correctly in page" src="https://github.com/npm/documentation/assets/27637/591ae0f1-e768-496e-98dd-5611bb4e4598">

Closes #789