### PR TITLE
Default table of contents to open on mobile

### DIFF
--- a/src/components/table-of-contents.js
+++ b/src/components/table-of-contents.js
@@ -33,7 +33,7 @@ const withTableOfContents = Component => {
 }
 
 export const Mobile = withTableOfContents(({items}) => {
-  const {getDetailsProps, open} = useDetails({})
+  const {getDetailsProps, open} = useDetails({defaultOpen: true})
   return (
     <Box sx={{display: ['block', null, 'none'], mb: 3}}>
       <Details {...getDetailsProps()}>


### PR DESCRIPTION
After #767, the table of contents used the `useDetails()` hook from `@primer/react`.

I believe #775 was reviewed to close https://github.com/github/accessibility-audits/issues/5936 and https://github.com/github/accessibility-audits/issues/5940. This PR implements a similar fix to #775 where the table of contents will always be open by default on small screens. One difference is that since it uses the `useDetails()` hook, if the user closes the table of contents, it will remain closed for the rest of the session.

Closes #776
Closes #775
