### PR TITLE
select cli version hover colour contrast ratio issue fix

### DIFF
--- a/src/components/variant-select.js
+++ b/src/components/variant-select.js
@@ -9,8 +9,8 @@ const VariantItem = ({title, shortName, url, active}) => (
   <ActionList.Item
     sx={{
       ':hover:not([aria-disabled])': {
-        backgroundColor: '#666D75',
-        color: '#FFFFFF',
+        backgroundColor: 'dropDown.backgroundColor',
+        color: 'dropDown.color',
       },
     }}
     as={LinkNoUnderline}

--- a/src/components/variant-select.js
+++ b/src/components/variant-select.js
@@ -6,7 +6,19 @@ import {LinkNoUnderline} from './link'
 import useLocationChange from '../hooks/use-location-change'
 
 const VariantItem = ({title, shortName, url, active}) => (
-  <ActionList.Item as={LinkNoUnderline} to={url} state={{scrollUpdate: false}} id={shortName} active={active}>
+  <ActionList.Item
+    sx={{
+      ':hover:not([aria-disabled])': {
+        backgroundColor: '#666D75',
+        color: '#FFFFFF',
+      },
+    }}
+    as={LinkNoUnderline}
+    to={url}
+    state={{scrollUpdate: false}}
+    id={shortName}
+    active={active}
+  >
     {title}
   </ActionList.Item>
 )

--- a/src/theme.js
+++ b/src/theme.js
@@ -7,6 +7,10 @@ export const NPM_RED = '#cb0000'
 export const npmTheme = deepmerge(theme, {
   colors: {
     logoBg: NPM_RED,
+    dropDown: {
+      backgroundColor: '#666D75',
+      color: '#FFFFFF',
+    },
   },
   colorSchemes: {
     light: {


### PR DESCRIPTION
The luminosity contrast ratio for the focus indicator over the 'Version 7.24.2 (Legacy release)' control is 1.1:1 which is less than the required contrast ratio 3:1.

Added hover foreground `#666D75`  , with white text `#FFFFFF` for more contrast ratio.


## References
  Fixes #5957
  url: https://github.com/github/accessibility-audits/issues/5957
  
  <img src="https://github.com/npm/documentation/assets/141764922/d262e001-b042-4753-98de-0efaf74357a5" alt="Sandbox screenshot" width="400" >

https://github.com/npm/documentation/assets/141764922/78506f56-b8be-4d8c-94a2-6fbb0bb9e82f

