### PR TITLE
feat: adding a skip to search anchor

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,15 @@
+import {SKIP_TO_SEARCH_ID} from './src/constants'
+
 export {default as wrapPageElement} from './src/page'
 export {default as wrapRootElement} from './src/root'
 
 export const shouldUpdateScroll = ({routerProps}) => {
   const {scrollUpdate = true} = routerProps.location.state ?? {}
   return scrollUpdate
+}
+
+export const onRouteUpdate = ({location, prevLocation}) => {
+  if (location.hash === `#${SKIP_TO_SEARCH_ID}` && prevLocation?.hash !== `#${SKIP_TO_SEARCH_ID}`) {
+    document.getElementById(SKIP_TO_SEARCH_ID)?.focus()
+  }
 }

--- a/src/components/skip-nav.js
+++ b/src/components/skip-nav.js
@@ -1,29 +1,16 @@
 import React from 'react'
-import {Box} from '@primer/react'
+import {Box, themeGet} from '@primer/react'
 import styled from 'styled-components'
 import Link from './link'
 import {SCROLL_MARGIN_TOP, SKIP_TO_CONTENT_ID} from '../constants'
 
-const SkipLinkBase = props => (
-  <Link
-    {...props}
-    href={`#${props.skipTarget}`}
-    sx={{
-      p: 3,
-      color: 'fg.onEmphasis',
-      backgroundColor: 'accent.emphasis',
-      fontSize: 1,
-    }}
-  >
-    {props.linkText}
-  </Link>
-)
-
-export const SkipLink = styled(SkipLinkBase)`
+export const SkipLink = styled(Link)`
+  color: ${themeGet('colors.accent.emphasis')};
+  padding: ${themeGet('space.1')};
   &:focus {
     text-decoration: underline;
   }
-`;
+`
 
 // The following rules are to ensure that the element is visually hidden, unless
 // it has focus. This is the recommended way to hide content from:
@@ -36,9 +23,24 @@ export const SkipBox = styled.div`
   position: absolute;
   transform: translateY(-100%);
   transition: transform 0.3s;
+  padding: ${themeGet('space.2')};
+  background-color: ${themeGet('colors.canvas.default')};
+  border: 1px solid ${themeGet('colors.accent.emphasis')};
+  border-top: 0;
+  font-size: ${themeGet('fontSizes.1')};
+  border-radius: 0 0 ${themeGet('radii.2')} ${themeGet('radii.2')};
+  
 
   &:focus-within {
     transform: translateY(0%);
+  }
+
+  & > * {
+    margin-right: ${themeGet('space.1')};
+  }
+
+  & > *:last-child {
+    margin-right: 0;
   }
 `
 

--- a/src/components/skip-nav.js
+++ b/src/components/skip-nav.js
@@ -2,14 +2,12 @@ import React from 'react'
 import {Box} from '@primer/react'
 import styled from 'styled-components'
 import Link from './link'
-import {SCROLL_MARGIN_TOP} from '../constants'
-
-const ID = 'skip-nav'
+import {SCROLL_MARGIN_TOP, SKIP_TO_CONTENT_ID} from '../constants'
 
 const SkipLinkBase = props => (
   <Link
     {...props}
-    href={`#${ID}`}
+    href={`#${props.skipTarget}`}
     sx={{
       p: 3,
       color: 'fg.onEmphasis',
@@ -17,33 +15,34 @@ const SkipLinkBase = props => (
       fontSize: 1,
     }}
   >
-    Skip to content
+    {props.linkText}
   </Link>
 )
+
+export const SkipLink = styled(SkipLinkBase)`
+  &:focus {
+    text-decoration: underline;
+  }
+`;
 
 // The following rules are to ensure that the element is visually hidden, unless
 // it has focus. This is the recommended way to hide content from:
 // https://webaim.org/techniques/css/invisiblecontent/#techniques
-export const SkipLink = styled(SkipLinkBase)`
+export const SkipBox = styled.div`
+  display: inline-flex;
   z-index: 20;
-  width: auto;
-  height: auto;
-  clip: auto;
-  position: absolute;
-  overflow: hidden;
   left: 10px;
+  gap: 3px;
+  position: absolute;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
 
-  &:not(:focus) {
-    clip: rect(1px, 1px, 1px, 1px);
-    clip-path: inset(50%);
-    height: 1px;
-    width: 1px;
-    margin: -1px;
-    padding: 0;
+  &:focus-within {
+    transform: translateY(0%);
   }
 `
 
-const SkipNavBase = props => <Box id={ID} {...props} />
+const SkipNavBase = props => <Box id={SKIP_TO_CONTENT_ID} {...props} />
 
 export const SkipNav = styled(SkipNavBase)`
   scroll-margin-top: ${SCROLL_MARGIN_TOP}px;

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,8 +6,8 @@ export const FULL_HEADER_HEIGHT = HEADER_HEIGHT + HEADER_BAR
 
 export const SCROLL_MARGIN_TOP = FULL_HEADER_HEIGHT + 24
 
-export const SKIP_TO_CONTENT_ID = "skip-to-content"
+export const SKIP_TO_CONTENT_ID = 'skip-to-content'
 
-export const SKIP_TO_SEARCH_ID = "search-box-input"
+export const SKIP_TO_SEARCH_ID = 'search-box-input'
 
 export const CLI_PATH = '/cli'

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,4 +6,8 @@ export const FULL_HEADER_HEIGHT = HEADER_HEIGHT + HEADER_BAR
 
 export const SCROLL_MARGIN_TOP = FULL_HEADER_HEIGHT + 24
 
+export const SKIP_TO_CONTENT_ID = "skip-to-content"
+
+export const SKIP_TO_SEARCH_ID = "search-box-input"
+
 export const CLI_PATH = '/cli'

--- a/src/page.js
+++ b/src/page.js
@@ -4,7 +4,8 @@ import {createGlobalStyle} from 'styled-components'
 import Slugger from 'github-slugger'
 import Header from './components/header'
 import Sidebar from './components/sidebar'
-import {SkipLink} from './components/skip-nav'
+import {SkipBox, SkipLink} from './components/skip-nav'
+import {SKIP_TO_CONTENT_ID, SKIP_TO_SEARCH_ID} from './constants'
 
 import {PageProvider} from './hooks/use-page'
 import Layout from './layout'
@@ -27,7 +28,10 @@ const PageElement = ({element, props}) => {
   return (
     <BaseStyles>
       <GlobalStyles />
-      <SkipLink />
+      <SkipBox>
+        <SkipLink linkText="Skip to search" skipTarget={SKIP_TO_SEARCH_ID} />
+        <SkipLink linkText="Skip to content" skipTarget={SKIP_TO_CONTENT_ID} />
+      </SkipBox>
       <PageProvider value={page}>
         <Box sx={{display: 'flex', flexDirection: 'column', minHeight: '100vh'}}>
           <Header />

--- a/src/page.js
+++ b/src/page.js
@@ -29,8 +29,8 @@ const PageElement = ({element, props}) => {
     <BaseStyles>
       <GlobalStyles />
       <SkipBox>
-        <SkipLink linkText="Skip to search" skipTarget={SKIP_TO_SEARCH_ID} />
-        <SkipLink linkText="Skip to content" skipTarget={SKIP_TO_CONTENT_ID} />
+        <SkipLink href={`#${SKIP_TO_SEARCH_ID}`}>Skip to search</SkipLink>
+        <SkipLink href={`#${SKIP_TO_CONTENT_ID}`}>Skip to content</SkipLink>
       </SkipBox>
       <PageProvider value={page}>
         <Box sx={{display: 'flex', flexDirection: 'column', minHeight: '100vh'}}>


### PR DESCRIPTION
UPD: due to accessibility-related reasons, the `autofocus` attribute idea was parked. Instead, this PR adds the "Skip to search" anchor.

Original:
This PR is a suggestion to add the `autofocus` attribute to the search input. The main driver is that when opening the [docs.npmjs.com](https://docs.npmjs.com/) page, a user needs to set the focus in the input manually to start searching.

There are, however, some [accessibility trade-offs](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus#accessibility_considerations) to consider. Therefore, I am open to any feedback and outcome.