### PR TITLE
doc: update npm-config link in npm-edit descriptions

### DIFF
--- a/content/cli/v10/commands/npm-edit.mdx
+++ b/content/cli/v10/commands/npm-edit.mdx
@@ -45,7 +45,7 @@ Note: This command is unaware of workspaces.
 
 ### Description
 
-Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](npm-config).)
+Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](commands/npm-config).)
 
 After it has been edited, the package is rebuilt so as to pick up any changes in compiled packages.
 

--- a/content/cli/v6/commands/npm-edit.mdx
+++ b/content/cli/v6/commands/npm-edit.mdx
@@ -27,7 +27,7 @@ npm edit <pkg>[/<subpkg>...]
 
 ### Description
 
-Selects a (sub)dependency in the current working directory and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](npm-config).)
+Selects a (sub)dependency in the current working directory and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](commands/npm-config).)
 
 After it has been edited, the package is rebuilt so as to pick up any changes in compiled packages.
 

--- a/content/cli/v7/commands/npm-edit.mdx
+++ b/content/cli/v7/commands/npm-edit.mdx
@@ -29,7 +29,7 @@ Note: This command is unaware of workspaces.
 
 ### Description
 
-Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](npm-config).)
+Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](commands/npm-config).)
 
 After it has been edited, the package is rebuilt so as to pick up any changes in compiled packages.
 

--- a/content/cli/v8/commands/npm-edit.mdx
+++ b/content/cli/v8/commands/npm-edit.mdx
@@ -29,7 +29,7 @@ Note: This command is unaware of workspaces.
 
 ### Description
 
-Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](npm-config).)
+Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](commands/npm-config).)
 
 After it has been edited, the package is rebuilt so as to pick up any changes in compiled packages.
 

--- a/content/cli/v9/commands/npm-edit.mdx
+++ b/content/cli/v9/commands/npm-edit.mdx
@@ -29,7 +29,7 @@ Note: This command is unaware of workspaces.
 
 ### Description
 
-Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](npm-config).)
+Selects a dependency in the current project and opens the package folder in the default editor (or whatever you've configured as the npm `editor` config -- see [`npm-config`](commands/npm-config).)
 
 After it has been edited, the package is rebuilt so as to pick up any changes in compiled packages.
 


### PR DESCRIPTION
Fixed some broken links in the 'npm-edit' command docs (v6, v7, v8, v9, v10). They pointed to 'npm-config' before but now they're heading to the right place, 'commands/npm-config'. 

Your review is appreciated.
