### PR TITLE
Use import statement instead of require

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/using-npm-packages-in-your-projects.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/using-npm-packages-in-your-projects.mdx
@@ -8,13 +8,13 @@ Once you have [installed a package][install-pkg] in `node_modules`, you can use 
 
 ### Node.js module
 
-If you are creating a Node.js module, you can use a package in your module by passing it as an argument to the `require` function.
+If you are creating a Node.js module, you can use a package in your module by importing it with the `import` statement.
 
 ```javascript
-var lodash = require('lodash');
+// index.mjs
+import chalk from 'chalk';
 
-var output = lodash.without([1, 2, 3], 1);
-console.log(output);
+console.log(chalk.blue('Hello world!'));
 ```
 
 ### package.json file
@@ -36,7 +36,7 @@ To use a scoped package, simply include the scope wherever you use the package n
 ### Node.js module
 
 ```js
-var projectName = require("@scope/package-name")
+import packageName from "@scope/package-name";
 ```
 
 ### package.json file
@@ -51,15 +51,21 @@ In `package.json`:
 }
 ```
 
+## Resolving "Cannot use import statement outside a module" error
+
+The error message gives you two options to handle this,
+- Add `"type": "module"` field to your `package.json`, or
+- Use `.mjs` file extension instead of `.js`.
+
 ## Resolving "Cannot find module" errors
 
-If you have not properly installed a package, you will receive an error when you try to use it in your code. For example, if you reference the `lodash` package without installing it, you would see the following error:
+If you have not properly installed a package, you will receive an error when you try to use it in your code. For example, if you reference the `chalk` package without installing it, you would see the following error:
 
 ```
 module.js:340
     throw err;
           ^
-Error: Cannot find module 'lodash'
+Error: Cannot find module 'chalk'
 ```
 
 - For scoped packages, run `npm install <@scope/package_name>`


### PR DESCRIPTION
<!-- What / Why -->

This pull request updates the existing guide to reflect the modern JavaScript module system, transitioning from CommonJS `require` syntax to ESModules `import` syntax. With Node.js now offering [robust support for ESModules](https://nodejs.org/docs/latest-v20.x/api/esm.html#enabling), it is beneficial for new learners to start with the `import` syntax for several reasons:

- **Future-Proofing**: The JavaScript ecosystem has been steadily moving towards ESModules as the standard for quite some time. Learning `import` syntax prepares developers for up-to-date development practices.
- **Static Analysis**: ESModules allow for static analysis of code, enabling tree shaking and other optimization tools that can lead to more efficient bundling and reduced code sizes.
- **Interoperability**: ESModules are natively supported in browsers, making the code written for Node.js more consistent with frontend modules, thus simplifying full-stack development.

The changes include:

Replacing `require()` statements with `import` declarations.
Highlighting 2 ways Node.js can run ESModules, such as using `.mjs` file extensions or adding `"type": "module"` in package.json.
This update ensures developers have the current up-to-date information on module usage, promoting more efficient, future-proof codebases.


<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
