### PR TITLE
Relocate package naming guidelines to one location

### DIFF
--- a/content/cli/v10/configuring-npm/package-json.mdx
+++ b/content/cli/v10/configuring-npm/package-json.mdx
@@ -37,21 +37,7 @@ A lot of the behavior described in this document is affected by the config setti
 
 If you plan to publish your package, the _most_ important things in your package.json are the name and version fields as they will be required. The name and version together form an identifier that is assumed to be completely unique. Changes to the package should come along with changes to the version. If you don't plan to publish your package, the name and version fields are optional.
 
-The name is what your thing is called.
-
-Some rules:
-
-- The name must be less than or equal to 214 characters. This includes the scope for scoped packages.
-- The names of scoped packages can begin with a dot or an underscore. This is not permitted without a scope.
-- New packages must not have uppercase letters in the name.
-- The name ends up being part of a URL, an argument on the command line, and a folder name. Therefore, the name can't contain any non-URL-safe characters.
-
-Some tips:
-
-- Don't use the same name as a core Node module.
-- Don't put "js" or "node" in the name. It's assumed that it's js, since you're writing a package.json file, and you can specify the engine using the "engines" field. (See below.)
-- The name will probably be passed as an argument to require(), so it should be something short, but also reasonably descriptive.
-- You may want to check the npm registry to see if there's something by that name already, before you get too attached to it. [https://www.npmjs.com/](https://www.npmjs.com/)
+The name is what your package is called. It should follow [some rules](/packages-and-modules/contributing-packages-to-the-registry/package-name-guidelines).
 
 A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See [`scope`](/cli/v10/using-npm/scope) for more detail.
 

--- a/content/packages-and-modules/contributing-packages-to-the-registry/package-name-guidelines.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/package-name-guidelines.mdx
@@ -2,18 +2,14 @@
 title: Package name guidelines
 ---
 
-When choosing a name for your package, choose a name that
+There are a rules the name for your package must follow. Your name should:
 
-- is unique
-- is descriptive
-- meets [npm policy guidelines][policies]. For example, do not give your package an offensive name, and do not use someone else's trademarked name or violate the [npm trademark policy][npm-trademark].
-
-Additionally, when choosing a name for an [**unscoped** package][create-unscoped], also choose a name that
-
-- is not already owned by someone else
-- is not spelled in a similar way to another package name
-- will not confuse others about authorship
+- Meet npm's [policy guidelines][policies] and [trademark policy][npm-trademark].
+- Be less than or equal to 214 characters. This includes the scope for scoped packages.
+- Not begin with a dot (`.`) or underscore (`_`), if unscoped.
+- Not have uppercase letters in the name.
+- Not contain any non-URL-safe characters.
+- Not contain only numerical characters.
 
 [policies]: https://www.npmjs.com/policies
 [npm-trademark]: https://docs.npmjs.com/policies/disputes#trademarks
-[create-unscoped]: creating-and-publishing-unscoped-public-packages


### PR DESCRIPTION
## What / Why
Relocates all package naming guidelines to one place.

## References
Fixes #969.