### PR TITLE
fix: update adding a collaborator

### DIFF
--- a/content/packages-and-modules/updating-and-managing-your-published-packages/adding-collaborators-to-private-packages-owned-by-a-user-account.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/adding-collaborators-to-private-packages-owned-by-a-user-account.mdx
@@ -14,10 +14,11 @@ When you add a member to your package, they are sent an email inviting them to t
 
 ## Granting access to a private user package on the web
 
-1. On the [npm website][npmjs-com], go to the package to which you want to add a collaborator: `https://www.npmjs.com/package/<your-package-name>`
-2. On the package page, under "Collaborators", click **+**.
-3. Enter the npm username of the collaborator.
-4. Click **Submit**.
+1. On the [npm website][npmjs-com], go to the package to which you want to add a collaborator: `https://www.npmjs.com/package/<your-package-name>`.
+2. On the package page, click the "Settings" tab.
+3. Go to the "Invite maintainer" section.
+4. Enter the npm username of the collaborator.
+5. Click **Invite**.
 
 ## Granting private package access from the command line interface
 


### PR DESCRIPTION
The current doc on adding collaborator is outdated there's no **+** sign anymore on the package page. 