### PR TITLE
fix: npm audit cmd example keys link

### DIFF
--- a/content/cli/v10/commands/npm-audit.mdx
+++ b/content/cli/v10/commands/npm-audit.mdx
@@ -105,7 +105,7 @@ Keys response:
 - `scheme`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI
 - `key`: base64 encoded public key
 
-See this [example key's response from the public npm registry](https://registry.npmjs.org/-/npm/v1/keys").
+See this [example key's response from the public npm registry](https://registry.npmjs.org/-/npm/v1/keys).
 
 ### Audit Endpoints
 

--- a/content/cli/v8/commands/npm-audit.mdx
+++ b/content/cli/v8/commands/npm-audit.mdx
@@ -85,7 +85,7 @@ Keys response:
 - `scheme`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI
 - `key`: base64 encoded public key
 
-See this [https://registry.npmjs.org/-/npm/v1/keys](example key's response from the public npm registry).
+See this [example key's response from the public npm registry](https://registry.npmjs.org/-/npm/v1/keys).
 
 ### Audit Endpoints
 

--- a/content/cli/v9/commands/npm-audit.mdx
+++ b/content/cli/v9/commands/npm-audit.mdx
@@ -89,7 +89,7 @@ Keys response:
 - `scheme`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI
 - `key`: base64 encoded public key
 
-See this [example key's response from the public npm registry](https://registry.npmjs.org/-/npm/v1/keys").
+See this [example key's response from the public npm registry](https://registry.npmjs.org/-/npm/v1/keys).
 
 ### Audit Endpoints
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Link to keys example was broken due to `"` appended at the end. 

In v8, Markdown syntax was incorrect


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
