### PR TITLE
fix(typo): change keydid to keyid

### DIFF
--- a/content/packages-and-modules/securing-your-code/about-registry-signatures.mdx
+++ b/content/packages-and-modules/securing-your-code/about-registry-signatures.mdx
@@ -60,7 +60,7 @@ The `keyid` must match one of the public signing keys below.
 Keys response:
 
 - `expires`: null or a simplified extended [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601): `YYYY-MM-DDTHH:mm:ss.sssZ`
-- `keydid`: sha256 fingerprint of the public key
+- `keyid`: sha256 fingerprint of the public key
 - `keytype`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI
 - `scheme`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI
 - `key`: base64 encoded public key


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Fix typo `keydid` to `keyid`.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
