### PR TITLE
Move GitLab example for npm build provenance

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -101,23 +101,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
-### Example GitLab CI job
-
-This example job publishes a package to the npm registry with provenance when a git tag is pushed. Don’t forget to define the `NPM_TOKEN` variable in your GitLab project settings.
-
-```yaml
-publish:
-  image: 'node:20'
-  rules:
-    - if: $CI_COMMIT_TAG
-  id_tokens:
-    SIGSTORE_ID_TOKEN:
-      aud: sigstore
-  script:
-    - npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-    - npm publish --provenance --access public
-```
-
 ### Using third-party package publishing tools
 
 If you publish your packages with tools that do not directly invoke the `npm publish` command, you can do one of the following in your GitHub Actions workflow to publish your packages with provenance.
@@ -143,6 +126,23 @@ If you publish your packages with tools that do not directly invoke the `npm pub
 ## Publishing packages with provenance via GitLab CI/CD
 
 In order to establish provenance, you must use a supported cloud CI/CD provider and a cloud-hosted runner to publish your packages. GitLab CI/CD is a supported CI/CD platform that allows you to automate software development tasks. For more information, see [Generating provenance in GitLab CI/CD][gitlab-ci-cd-docs] in the GitLab documentation.
+
+### Example GitLab CI job
+
+This example job publishes a package to the npm registry with provenance when a git tag is pushed. Don’t forget to define the `NPM_TOKEN` variable in your GitLab project settings.
+
+```yaml
+publish:
+  image: 'node:20'
+  rules:
+    - if: $CI_COMMIT_TAG
+  id_tokens:
+    SIGSTORE_ID_TOKEN:
+      aud: sigstore
+  script:
+    - npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+    - npm publish --provenance --access public
+```
 
 ## Verifying provenance attestations
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

When reading the [npm build provenance doc](https://docs.npmjs.com/generating-provenance-statements), I noticed that the GitLab example was under the GitHub Actions section. This PR just moves the GitLab example to the GitLab section of the doc instead.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
I didn't open an issue since it's a tiny, cosmetic change.
