### PR TITLE
fix: clarify provenance repository match url is case-sensitive

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -36,7 +36,7 @@ Before you can publish your packages with provenance, you must:
 
 - Install the latest version of the npm CLI (ensure you are on `9.5.0+` as older versions don't support npm provenance). For more information, see "[Try the latest stable version of npm][update-npm]."
 
-- Ensure your `package.json` is configured with a public `repository` that matches where you are publishing with provenance from.
+- Ensure your `package.json` is configured with a public `repository` that matches (case-sensitive) where you are publishing with provenance from.
 
 - Set up automation with a supported CI/CD provider to publish your packages to the npm registry. The following providers are supported:
   - GitHub Actions. For more information, see "[Publishing packages with provenance via GitHub Actions][github-provenance]."


### PR DESCRIPTION
Clarify that the repository url is matched case-sensitive so users don't need to find out by trial and error.

GitHub user names are case-insensitive which means you can use `/username/repository` or `/UserName/repository` as valid repository url. But provenance seems to check for exact match which can be confusing to people adding provenance to their package on GitHub when the url does not satisfy provenance.