### PR TITLE
Add example of undeprecating entire package

### DIFF
--- a/content/packages-and-modules/updating-and-managing-your-published-packages/deprecating-and-undeprecating-packages-or-package-versions.mdx
+++ b/content/packages-and-modules/updating-and-managing-your-published-packages/deprecating-and-undeprecating-packages-or-package-versions.mdx
@@ -74,7 +74,13 @@ If you have two-factor auth, add a one-time password to the command, `--otp=1234
 
 To undeprecate a package, replace `"<message>"` with `""` (an empty string) in one of the above commands.
 
-For example, to undeprecate a package version, run the following command, replacing `<package-name>` with the name of your package, and `<version>` with your version number:
+For example, to undeprecate an entire package, run the following command, replacing `<package-name>` with the name of your package, and `<version>` with your version number:
+
+```
+npm deprecate <package-name> ""
+```
+
+Or to undeprecate only a single package version, run the following command, replacing `<package-name>` with the name of your package, and `<version>` with your version number:
 
 ```
 npm deprecate <package-name>@<version> ""


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Hi npm team, first of all, thanks for your continued effort on npm and documentation!

Add a command example of undeprecating an entire package, which appears to be missing from the documentation currently.

The closest thing currently is this heading + sentence:

> # Undeprecating a package or version
>
> To undeprecate a package, replace "<message>" with "" (an empty string) in one of the above commands.

But I would argue it's a bit open to interpretation, and doesn't explicitly show the command to undeprecate an entire package.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

--