### PR TITLE
fix: clarify the file name to be used

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-node-js-modules.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-node-js-modules.mdx
@@ -25,7 +25,7 @@ For more information on `package.json` files, see "[Creating a package.json file
 
 ## Create the file that will be loaded when your module is required by another application
 
-In the file, add a function as a property of the `exports` object. This will make the function available to other code:
+Create a file with the same you provided in the `main` field. In that file, add a function as a property of the `exports` object. This will make the function available to other code:
 
 ```
 exports.printMsg = function() {

--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-node-js-modules.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-node-js-modules.mdx
@@ -25,7 +25,7 @@ For more information on `package.json` files, see "[Creating a package.json file
 
 ## Create the file that will be loaded when your module is required by another application
 
-Create a file with the same you provided in the `main` field. In that file, add a function as a property of the `exports` object. This will make the function available to other code:
+Create a file with the same name you provided in the `main` field. In that file, add a function as a property of the `exports` object. This will make the function available to other code:
 
 ```
 exports.printMsg = function() {


### PR DESCRIPTION
As I was following the steps in this page - https://docs.npmjs.com/creating-node-js-modules, I noticed the following error when using the published package in the  test-directory:

`Error: Cannot find module 'D:\Learning\npm-docs\use-hello\node_modules\@andrewnessindev\hello\index.js'. Please verify that the package.json has a valid "main" entry`

It turned out that I missed providing the main entry even though this [page already mentions to provide it](https://github.com/npm/documentation/blob/2e10e4ed46f0f58adf4c165e8ef21599bc3b325f/content/packages-and-modules/contributing-packages-to-the-registry/creating-node-js-modules.mdx?plain=1#L20). However, it might be more helpful if the docs clarify which file is referred to when[ it says, "In the file"](https://github.com/npm/documentation/blob/2e10e4ed46f0f58adf4c165e8ef21599bc3b325f/content/packages-and-modules/contributing-packages-to-the-registry/creating-node-js-modules.mdx?plain=1#L28).

This is my first commit! I followed the instruction it the `contributing.md` file for the commit message. I did not see a requirement to raise an issue first! Please do let me know if I have to raise an issue first or if I have missed anything else.