### PR TITLE
docs: how to run on windows locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This is the documentation for [https://docs.npmjs.com/](https://docs.npmjs.com/)
 
 First, `npm install` the dependencies. This will install Gatsby, et al.
 
-Next, `npm run develop` to start the test server to view your changes. The Gatsby server will be started on port 8000. You can navigate to `http://localhost:8000` to view the site live.
+Next, `npm run develop` to start the test server to view your changes. The Gatsby server will be started on port 8000. You can navigate to `http://localhost:8000` to view the site live. If you're on Windows, change the syntax for setting environment variables in the `package.json` file based on your terminal before running this command. The syntax for command prompt is `set ENV_VAR=value & command`.
 
 In order to cut down on the time it takes `npm run develop` to complete, you can use the environment variables `GATSBY_CONTENT_ALLOW` and `GATSBY_CONTENT_IGNORE` to only build some pages.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This is the documentation for [https://docs.npmjs.com/](https://docs.npmjs.com/)
 
 First, `npm install` the dependencies. This will install Gatsby, et al.
 
-Next, `npm run develop` to start the test server to view your changes. The Gatsby server will be started on port 8000. You can navigate to `http://localhost:8000` to view the site live. If you're on Windows, change the syntax for setting environment variables in the `package.json` file based on your terminal before running this command. The syntax for command prompt is `set ENV_VAR=value & command`.
+Next, `npm run develop` to start the test server to view your changes. The Gatsby server will be started on port 8000. You can navigate to `http://localhost:8000` to view the site live. This npm script doesn't work on Windows terminals, run it manually using appropriate syntax for your terminal. The syntax for command prompt is `set PARCEL_WORKERS=0 & npm run gatsby develop`.
 
 In order to cut down on the time it takes `npm run develop` to complete, you can use the environment variables `GATSBY_CONTENT_ALLOW` and `GATSBY_CONTENT_IGNORE` to only build some pages.
 


### PR DESCRIPTION
The syntax for setting env variables is different for powershell and command prompt, so I have mentioned only the command prompt syntax to keep it simple. I think it's sufficient if Windows users just know the syntax needs to be updated.

We could add the windows syntax for setting `GATSBY_CONTENT_ALLOW` and `GATSBY_CONTENT_IGNORE` too, but it feels like an overkill.

Tested by changing the syntax in `package.json` file:
<img width="623" alt="image" src="https://github.com/npm/documentation/assets/16577820/ce29409c-e301-4f65-abad-42269d94718e">


Closes #1172
