### PR TITLE
docs: update generating-provenance-statements page

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -112,6 +112,7 @@ If you publish your packages with tools that do not directly invoke the `npm pub
     "provenance": true
   },
   ```
+
 - **Add an `.npmrc` file:** You can add an `.npmrc` file to your project with the following entry:
 
   ```ini

--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -89,12 +89,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm
       - run: npm ci
       - run: npm publish --provenance --access public
         env:
@@ -107,12 +106,14 @@ If you publish your packages with tools that do not directly invoke the `npm pub
 
 - **Configure environment variables:** In your GitHub Actions workflow, you can use an environment variable called `NPM_CONFIG_PROVENANCE`, and set it to `true`.
 - **Configure your `package.json` file:** You can add a `publishConfig` block to your `package.json` file:
+
   ```json
   "publishConfig": {
     "provenance": true
   },
   ```
 - **Add an `.npmrc` file:** You can add an `.npmrc` file to your project with the following entry:
+
   ```ini
   provenance=true
   ```
@@ -129,7 +130,7 @@ In order to establish provenance, you must use a supported cloud CI/CD provider 
 
 ### Example GitLab CI job
 
-This example job publishes a package to the npm registry with provenance when a git tag is pushed. Don’t forget to define the `NPM_TOKEN` variable in your GitLab project settings.
+This example job publishes a package to the npm registry with provenance when a git tag is pushed. Don't forget to define the `NPM_TOKEN` variable in your GitLab project settings.
 
 ```yaml
 publish:


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR updates the "Generating provenance statements" page, updating the GitHub action and introducing minor fixes to the page.

> [!NOTE]
> I have removed the` - run: npm install -g npm` line from the GitHub action since `actions/setup-node` will perform the same.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

N/A