### PR TITLE
Update index.mdx as Twitter is now known as 'X'.

### DIFF
--- a/content/about-npm/index.mdx
+++ b/content/about-npm/index.mdx
@@ -46,7 +46,7 @@ You can also use a private npm package registry like [GitHub Packages](https://g
 
 ## Learn more
 
-To learn more about npm as a product, upcoming new features, and interesting uses of npm be sure to follow [@npmjs](https://twitter.com/npmjs) on Twitter.
+To learn more about npm as a product, upcoming new features, and interesting uses of npm be sure to follow [@npmjs](https://twitter.com/npmjs) on X, formerly known as Twitter.
 
 For mentoring, tutorials, and learning, visit [node school](https://nodeschool.io). Consider attending or hosting a nodeschool event (usually free!) at a site near you, or use the self-help tools you can find on the site.
 


### PR DESCRIPTION
I suggest you update 'Twitter' to either 'X', or 'X, formery known as Twitter', and update the link to: https://x.com/npmjs (although it currently still works as is).

My proposed changes go with the latter, in the hope that Twitter will one day be known again as Twitter ;-)