### PR TITLE
Update generating-provenance-statements.mdx --- use the `published` event in the GH Action workflow

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -81,7 +81,7 @@ This example workflow publishes a package to the npm registry with provenance.
 name: Publish Package to npmjs
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
On the [Generating provenance statements](https://docs.npmjs.com/generating-provenance-statements) page, it has a sample GitHub Actions workflow that has this config:
```yaml
on:
  release:
    types: [created]
```

However, on GitHub's [Publishing Node.js packages](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) page, the example workflow has
```yaml
on:
  release:
    types: [published]
```
So it uses `published` instead of `created`.

Tracking down the difference was somewhat difficult... On the [Events that trigger workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release) page under "release", it does not document the semantics of the individual events. But it links to the [Webhook events and payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads#release) page, where `created` and `published` are documented.

For `created`, it says:
> A draft was saved, or a release or pre-release was published without previously being saved as a draft.

For `published`, it says:
> A release, pre-release, or draft of a release was published.

So it seems that `created` would trigger it when a release draft is created. This doesn't seem like the right time, because the user's workflow when creating draft releases is: 1) create the release draft, then 2) edit it later, and finally 3) release it.

From [Managing releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository):
> To work on the release later, click **Save draft**.

I may be wrong about this, since I'm just getting started with GH Actions and Releases. So please disregard in that case.