### PR TITLE
chore: update versions in publish action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,6 @@ jobs:
     name: REUSE Compliance Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,11 @@ jobs:
         run: npm rebuild
 
       - name: Setup Pages
-        uses: actions/configure-pages@v1
+        uses: actions/configure-pages@v4
 
       - name: Restore cache
         id: cache-gatsby
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-gatsby-${{ github.ref_name }}
           path: |
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           key: ${{ steps.cache-gatsby.outputs.cache-primary-key }}
           path: |
@@ -71,13 +71,14 @@ jobs:
             .cache
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './public'
 
   deploy:
     permissions:
       pages: write
+      actions: read
       id-token: write
     environment:
       name: github-pages
@@ -87,6 +88,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
         with:
           preview: ${{ github.event_name == 'pull_request' }}

--- a/scripts/template-oss/ci-yml.hbs
+++ b/scripts/template-oss/ci-yml.hbs
@@ -11,6 +11,6 @@
     name: REUSE Compliance Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1

--- a/scripts/template-oss/publish-yml.hbs
+++ b/scripts/template-oss/publish-yml.hbs
@@ -27,11 +27,11 @@ jobs:
         run: npm rebuild
 
       - name: Setup Pages
-        uses: actions/configure-pages@v1
+        uses: actions/configure-pages@v4
       
       - name: Restore cache
         id: cache-gatsby
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: $\{{ runner.os }}-gatsby-$\{{ github.ref_name }}
           path: |
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
 
       - name: Save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           key: $\{{ steps.cache-gatsby.outputs.cache-primary-key }}
           path: |
@@ -52,13 +52,14 @@ jobs:
             .cache
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './public'
 
   deploy:
     permissions:
       pages: write
+      actions: read
       id-token: write
     environment:
       name: github-pages
@@ -68,6 +69,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
         with:
           preview: $\{{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
The only difference that looks like it requires a change is in the new permissions needed for upload-pages-artifact
