### PR TITLE
docs: update npm-global folder location

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
@@ -31,7 +31,7 @@ To minimize the chance of permissions errors, you can configure npm to use a dif
 2. On the command line, in your home directory, create a directory for global installations:
 
    ```
-   mkdir ~/.npm-global/lib
+   mkdir -p ~/.npm-global/lib
    ```
 
 3. Configure npm to use the new directory path:

--- a/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
@@ -31,7 +31,7 @@ To minimize the chance of permissions errors, you can configure npm to use a dif
 2. On the command line, in your home directory, create a directory for global installations:
 
    ```
-   mkdir ~/.npm-global
+   mkdir ~/.npm-global/lib
    ```
 
 3. Configure npm to use the new directory path:


### PR DESCRIPTION
added a sub folder "lib"

<!-- What / Why -->

On following the steps mentioned in https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally, 
OS : macOS

After completing step 5, i tried doing `npx lighthouse https://google.com` and it failed with following error 

<img width="1334" alt="Screenshot 2024-09-05 at 12 19 59 PM" src="https://github.com/user-attachments/assets/82954e23-3c10-46f5-bdb3-35689ad0ba35">

(Note: website url is just for an example)
(Note: i ran the above command, instead of step 6)

<!-- Describe the request in detail. What it does and why it's being changed. -->

To fix this, make the following change to step 2.
 Add a subfolder "lib"

## References

I can create an issue if needed