### PR TITLE
[Accessibility bug] set colour contrast ratio 4.5.1

### DIFF
--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -120,7 +120,7 @@ function Code({className = '', prompt, children}) {
                     ...getTokenProps({token, key}),
                     style:
                       getTokenProps({token, key}).className === 'token comment'
-                        ? {...getTokenProps({token, key}).style, color: '#747459'}
+                        ? {...getTokenProps({token, key}).style, color: '#747458'}
                         : getTokenProps({token, key}).style,
                   }}
                 />


### PR DESCRIPTION
This pull request includes a small change to the `src/mdx/code.js` file. The change corrects the color code used for comments in the `Code` component.

* [`src/mdx/code.js`](diffhunk://#diff-f3f4e897983cba6337e020c78ef03c356c88f8868bcd19c465eb3c07e8b96625L123-R123): Adjusted the color code for comments from `#747459` to `#747458` in the `Code` component.