### PR TITLE
Update docs to include note about submodules & workspaces

### DIFF
--- a/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
+++ b/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
@@ -39,7 +39,7 @@ Git URLs used for npm packages can be formatted in the following ways:
 
 The `commit-ish` can be any tag, sha, or branch that can be supplied as an argument to `git checkout`. The default `commit-ish` is `HEAD`.
 
-Installing any package directly from git will not install [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) or workspaces. 
+Installing any package directly from git will not install [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) or workspaces.
 
 ## About modules
 

--- a/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
+++ b/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
@@ -39,6 +39,8 @@ Git URLs used for npm packages can be formatted in the following ways:
 
 The `commit-ish` can be any tag, sha, or branch that can be supplied as an argument to `git checkout`. The default `commit-ish` is `HEAD`.
 
+Installing any package directly from git will not install [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) or workspaces. 
+
 ## About modules
 
 A **module** is any file or directory in the `node_modules` directory that can be loaded by the Node.js `require()` function.


### PR DESCRIPTION
Currently we don't document that packages installed through git will not install git submodules in that repo or npm workspaces.

Should clarify:

https://github.com/npm/cli/issues/7554
https://github.com/npm/cli/issues/2774