### PR TITLE
[Fix Accessibility Bug] Refactor code.js to improve syntax highlighting colors

### DIFF
--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -91,15 +91,14 @@ const CodeBlock = ({children, code, className, style}) => (
   </Box>
 )
 
-function getCustomTokenStyle(tokenProps) {
-  const {className, style} = tokenProps
+function getCustomTokenStyle({className, style}) {
   const colorMap = {
     'token comment': '#747458',
     'token parameter variable': '#277d7b',
     'token function': '#cf3846',
   }
 
-  return className in colorMap ? {...style, color: colorMap[className]} : style
+  return colorMap[className] ? {...style, color: colorMap[className]} : style
 }
 
 function Code({className = '', prompt, children}) {

--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -98,6 +98,8 @@ function getCustomTokenStyle(tokenProps) {
       return {...style, color: '#747458'}
     case 'token parameter variable':
       return {...style, color: '#277d7b'}
+    case 'token function':
+      return {...style, color: '#cf3846'}
     default:
       return style
   }

--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -118,10 +118,15 @@ function Code({className = '', prompt, children}) {
                   key={key}
                   {...{
                     ...getTokenProps({token, key}),
-                    style:
-                      getTokenProps({token, key}).className === 'token comment'
-                        ? {...getTokenProps({token, key}).style, color: '#747458'}
-                        : getTokenProps({token, key}).style,
+                    style: {
+                      ...getTokenProps({token, key}).style,
+                      color:
+                        getTokenProps({token, key}).className === 'token comment'
+                          ? '#747458'
+                          : getTokenProps({token, key}).className === 'token parameter variable'
+                            ? '#277d7b'
+                            : getTokenProps({token, key}).style.color,
+                    },
                   }}
                 />
               ))}

--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -45,8 +45,8 @@ export const InlineCode = styled.code`
 `
 const colorMap = {
   'token comment': '#747458',
-  'token parameter variable': '#277d7b',
   'token function': '#cf3846',
+  'token parameter variable': '#277d7b',
 }
 
 const MonoText = props => <Text sx={{fontFamily: 'mono', fontSize: 1}} {...props} />

--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -113,23 +113,13 @@ function Code({className = '', prompt, children}) {
         <CodeBlock className={highlightClassName} style={style} code={code}>
           {tokens.map((line, i) => (
             <Box key={i} {...getLineProps({line, key: i})}>
-              {line.map((token, key) => (
-                <MonoText
-                  key={key}
-                  {...{
-                    ...getTokenProps({token, key}),
-                    style: {
-                      ...getTokenProps({token, key}).style,
-                      color:
-                        getTokenProps({token, key}).className === 'token comment'
-                          ? '#747458'
-                          : getTokenProps({token, key}).className === 'token parameter variable'
-                            ? '#277d7b'
-                            : getTokenProps({token, key}).style.color,
-                    },
-                  }}
-                />
-              ))}
+              {line.map((token, key) => {
+                const tokenProps = getTokenProps({token, key})
+                const tokenStyle =
+                  tokenProps.className === 'token comment' ? {...tokenProps.style, color: '#747458'} : tokenProps.style
+
+                return <MonoText key={key} {...tokenProps} style={tokenStyle} />
+              })}
             </Box>
           ))}
         </CodeBlock>

--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -91,6 +91,18 @@ const CodeBlock = ({children, code, className, style}) => (
   </Box>
 )
 
+function getCustomTokenStyle(tokenProps) {
+  const {className, style} = tokenProps
+  switch (className) {
+    case 'token comment':
+      return {...style, color: '#747458'}
+    case 'token parameter variable':
+      return {...style, color: '#277d7b'}
+    default:
+      return style
+  }
+}
+
 function Code({className = '', prompt, children}) {
   if (prompt) {
     return (
@@ -115,9 +127,7 @@ function Code({className = '', prompt, children}) {
             <Box key={i} {...getLineProps({line, key: i})}>
               {line.map((token, key) => {
                 const tokenProps = getTokenProps({token, key})
-                const tokenStyle =
-                  tokenProps.className === 'token comment' ? {...tokenProps.style, color: '#747458'} : tokenProps.style
-
+                const tokenStyle = getCustomTokenStyle(tokenProps)
                 return <MonoText key={key} {...tokenProps} style={tokenStyle} />
               })}
             </Box>

--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -93,16 +93,13 @@ const CodeBlock = ({children, code, className, style}) => (
 
 function getCustomTokenStyle(tokenProps) {
   const {className, style} = tokenProps
-  switch (className) {
-    case 'token comment':
-      return {...style, color: '#747458'}
-    case 'token parameter variable':
-      return {...style, color: '#277d7b'}
-    case 'token function':
-      return {...style, color: '#cf3846'}
-    default:
-      return style
+  const colorMap = {
+    'token comment': '#747458',
+    'token parameter variable': '#277d7b',
+    'token function': '#cf3846',
   }
+
+  return className in colorMap ? {...style, color: colorMap[className]} : style
 }
 
 function Code({className = '', prompt, children}) {

--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -43,6 +43,11 @@ export const InlineCode = styled.code`
   background-color: ${themeGet('colors.neutral.muted')};
   border-radius: ${themeGet('radii.2')};
 `
+const colorMap = {
+  'token comment': '#747458',
+  'token parameter variable': '#277d7b',
+  'token function': '#cf3846',
+}
 
 const MonoText = props => <Text sx={{fontFamily: 'mono', fontSize: 1}} {...props} />
 
@@ -91,16 +96,6 @@ const CodeBlock = ({children, code, className, style}) => (
   </Box>
 )
 
-function getCustomTokenStyle({className, style}) {
-  const colorMap = {
-    'token comment': '#747458',
-    'token parameter variable': '#277d7b',
-    'token function': '#cf3846',
-  }
-
-  return colorMap[className] ? {...style, color: colorMap[className]} : style
-}
-
 function Code({className = '', prompt, children}) {
   if (prompt) {
     return (
@@ -125,7 +120,10 @@ function Code({className = '', prompt, children}) {
             <Box key={i} {...getLineProps({line, key: i})}>
               {line.map((token, key) => {
                 const tokenProps = getTokenProps({token, key})
-                const tokenStyle = getCustomTokenStyle(tokenProps)
+                const tokenStyle = colorMap[tokenProps.className]
+                  ? {...tokenProps.style, color: colorMap[tokenProps.className]}
+                  : tokenProps.style
+
                 return <MonoText key={key} {...tokenProps} style={tokenStyle} />
               })}
             </Box>


### PR DESCRIPTION
## WHAT
This pull request includes changes to improve the syntax highlighting in the `src/mdx/code.js` file by introducing a color mapping for different token types and simplifying the code structure.

Improvements to syntax highlighting:

* [`src/mdx/code.js`](diffhunk://#diff-f3f4e897983cba6337e020c78ef03c356c88f8868bcd19c465eb3c07e8b96625R46-R50): Added a `colorMap` object to define custom colors for specific token types such as comments, parameter variables, and functions.

Code simplification:

* [`src/mdx/code.js`](diffhunk://#diff-f3f4e897983cba6337e020c78ef03c356c88f8868bcd19c465eb3c07e8b96625L116-R128): Refactored the `Code` component to use the `colorMap` for setting token colors, simplifying the logic for applying styles to tokens.

## WHY
### BEFORE
<img width="835" alt="screen shot before" src="https://github.com/user-attachments/assets/5eabe1a8-58f2-4aea-8be2-85c378d47129">
<img width="229" alt="colour red before" src="https://github.com/user-attachments/assets/6fa14348-e459-4adb-8d40-3b82eeb27fa4">
<img width="229" alt="colour blue before" src="https://github.com/user-attachments/assets/8875765f-c878-4081-8055-de51c2af162d">


### AFTER
<img width="835" alt="screen shot after" src="https://github.com/user-attachments/assets/1a9ab2f5-4f65-4f78-840e-b9205e5ca6ca">
<img width="229" alt="colour red after" src="https://github.com/user-attachments/assets/769626c3-358f-4c97-a474-45c6a313c008">
<img width="229" alt="colour blue after" src="https://github.com/user-attachments/assets/474b603f-8b72-4c08-994b-26f6986bdb5d">
