### PR TITLE
[FIX Accessibility] Refactor code.js to add new color mapping for 'token assign-left variable'

### DIFF
--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -47,6 +47,7 @@ const colorMap = {
   'token comment': '#747458',
   'token function': '#cf3846',
   'token parameter variable': '#277d7b',
+  'token assign-left variable': '#277d7b',
 }
 
 const MonoText = props => <Text sx={{fontFamily: 'mono', fontSize: 1}} {...props} />


### PR DESCRIPTION
## WHAT
This pull request includes a small change to the `src/mdx/code.js` file. The change adds a new color mapping for the 'token assign-left variable' to the `colorMap` object.

* [`src/mdx/code.js`](diffhunk://#diff-f3f4e897983cba6337e020c78ef03c356c88f8868bcd19c465eb3c07e8b96625R50): Added color mapping for 'token assign-left variable' in the `colorMap` object.

## BEFORE & AFTER
<img width="375" alt="image" src="https://github.com/user-attachments/assets/f8bf78f4-f2cb-43b7-8b3c-e199e9ce9b33">
<img width="375" alt="image" src="https://github.com/user-attachments/assets/1af726ff-e629-4a60-a565-1d1278a9ff7d">

<img width="242" alt="image" src="https://github.com/user-attachments/assets/7f1db9d9-d4ea-470e-a5e5-aa91fad1125b">
<img width="242" alt="image" src="https://github.com/user-attachments/assets/58c1ca81-8799-4169-a3dd-5253afda5289">




## Reference
Missed in the [Previous PR](https://github.com/npm/documentation/pull/1305)