### PR TITLE
Accessibility#9196

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -14,16 +14,10 @@ import {announce} from '../util/aria-live'
 
 const SearchResults = ({results, getItemProps, highlightedIndex, isOpen}) => {
   const siteMetadata = useSiteMetadata()
-
-  React.useEffect(() => {
-    if (isOpen && (!results || results.length === 0)) {
-      announce('No results')
-    }
-  }, [results, isOpen])
-
   if (!results || results.length === 0) {
+    announce('No results')
     return (
-      <Box sx={{fontSize: 2, px: 3, py: 3}} aria-live="assertive">
+      <Box sx={{fontSize: 2, px: 3, py: 3}} aria-live="polite">
         No results
       </Box>
     )

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -22,7 +22,11 @@ const SearchResults = ({results, getItemProps, highlightedIndex, isOpen}) => {
   }, [results, isOpen])
 
   if (!results || results.length === 0) {
-    return <Box sx={{fontSize: 2, px: 3, py: 3}} aria-live="assertive">No results</Box>
+    return (
+      <Box sx={{fontSize: 2, px: 3, py: 3}} aria-live="assertive">
+        No results
+      </Box>
+    )
   }
 
   return (

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -10,12 +10,19 @@ import {LightTheme} from '../theme'
 import {LinkNoUnderline} from './link'
 import * as getNav from '../util/get-nav'
 import omit from '../util/omit'
+import {announce} from '../util/aria-live'
 
-const SearchResults = ({results, getItemProps, highlightedIndex}) => {
+const SearchResults = ({results, getItemProps, highlightedIndex, isOpen}) => {
   const siteMetadata = useSiteMetadata()
 
+  React.useEffect(() => {
+    if (isOpen && (!results || results.length === 0)) {
+      announce('No results')
+    }
+  }, [results, isOpen])
+
   if (!results || results.length === 0) {
-    return <Box sx={{fontSize: 2, px: 3, py: 3}}>No results</Box>
+    return <Box sx={{fontSize: 2, px: 3, py: 3}} aria-live="assertive">No results</Box>
   }
 
   return (

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -12,7 +12,7 @@ import * as getNav from '../util/get-nav'
 import omit from '../util/omit'
 import {announce} from '../util/aria-live'
 
-const SearchResults = ({results, getItemProps, highlightedIndex, isOpen}) => {
+const SearchResults = ({results, getItemProps, highlightedIndex}) => {
   const siteMetadata = useSiteMetadata()
   if (!results || results.length === 0) {
     announce('No results')


### PR DESCRIPTION
## What/Why

- Screen reader does not announce the search result information as `No results` on providing invalid input

## Changes

- [`src/components/search.js`](https://github.com/npm/documentation/pull/1319/files#diff-995f95946b0cbf613b5cf5d8d6335cb1612dcb31907922cd5da28be90a6ff442)

> Add `aria-live` as `polite` to Box element

> Add `announce` function to trigger screen reader announcing the `No results` message when there is no search result

## Before
![image](https://github.com/user-attachments/assets/5067f434-b86b-4383-899f-fe88b808abac)

## After

- The screen reader announces the search result information as `No results` on providing invalid input

## References

- https://github.com/github/accessibility-audits/issues/9196