### PR TITLE
docs: clarify package name rules

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
@@ -25,13 +25,13 @@ A `package.json` file:
 
 A `package.json` file must contain `"name"` and `"version"` fields.
 
-The `"name"` field contains your package's name, and must be lowercase, not contain any spaces, and may contain hyphens, dots, and underscores.
+The `"name"` field contains your package's name and *must* be lowercase *without* any spaces. May contain _hyphens_, _dots_, and _underscores_.
 
 The `"version"` field must be in the form `x.x.x` and follow the [semantic versioning guidelines][semver].
 
 ### Author field
 
-If you want to include package author information in `"author"` field, use the following format (email and website are both optional):
+If you want inclusive package author information, in the `"author"` field use the following format (email and website are both optional):
 
 ```
 Your Name <email@example.com> (https://example.com)

--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
@@ -25,7 +25,7 @@ A `package.json` file:
 
 A `package.json` file must contain `"name"` and `"version"` fields.
 
-The `"name"` field contains your package's name, and must be lowercase and one word, and may contain hyphens, dots and underscores.
+The `"name"` field contains your package's name, and must be lowercase, not contain any spaces, and may contain hyphens, dots, and underscores.
 
 The `"version"` field must be in the form `x.x.x` and follow the [semantic versioning guidelines][semver].
 

--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-a-package-json-file.mdx
@@ -25,7 +25,7 @@ A `package.json` file:
 
 A `package.json` file must contain `"name"` and `"version"` fields.
 
-The `"name"` field contains your package's name, and must be lowercase and one word, and may contain hyphens and underscores.
+The `"name"` field contains your package's name, and must be lowercase and one word, and may contain hyphens, dots and underscores.
 
 The `"version"` field must be in the form `x.x.x` and follow the [semantic versioning guidelines][semver].
 
@@ -34,7 +34,7 @@ The `"version"` field must be in the form `x.x.x` and follow the [semantic versi
 If you want to include package author information in `"author"` field, use the following format (email and website are both optional):
 
 ```
-Your Name <email@example.com> (http://example.com)
+Your Name <email@example.com> (https://example.com)
 ```
 
 ### Example
@@ -43,7 +43,7 @@ Your Name <email@example.com> (http://example.com)
 {
   "name": "my-awesome-package",
   "version": "1.0.0",
-  "author": "Your Name <email@example.com> (http://example.com)"
+  "author": "Your Name <email@example.com> (https://example.com)"
 }
 ```
 


### PR DESCRIPTION
- Add missing information as per Issue #1295 
- use secure hyperText Transfer Protocol : https
