### PR TITLE
core: Fix responsivity issue #802 

### DIFF
--- a/src/mdx/components.js
+++ b/src/mdx/components.js
@@ -179,7 +179,7 @@ export const UnorderedList = styled.ul`
   }
 
   li {
-    word-wrap: break-all;
+    word-break: break-all;
   }
 
   li > p {


### PR DESCRIPTION
Enabling responsive design on smaller screens by adding the `word-break` CSS property.


## References
  Fixes #802


