### PR TITLE
fix(search): Don't crash the page if a starts a search with the letter "H" 

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -31,7 +31,7 @@ const SearchResults = ({results, getItemProps, highlightedIndex}) => {
         // don't all appear the same in the search results
         const variant = getNav.getVariant(getNav.getVariantRoot(item.path), item.path)
         const hierarchy = getNav.getItemBreadcrumbs(item.path)
-        if (!variant || variant !== hierarchy[hierarchy.length - 1].shortName) {
+        if (!variant || variant !== hierarchy[hierarchy.length - 1]?.shortName) {
           hierarchy.pop()
         }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This issue (https://github.com/npm/documentation/issues/1333) from a couple weeks ago explains the problem pretty thoroughly so if you want more info just look there.

The short version though is that [when `hooks` were deprecated a few months ago](https://github.blog/changelog/2024-07-16-sunset-notice-npm-hooks-api-endpoints/) it surfaced an issue where if a query has a result that  has no `hierarchy` matches the entire page will crash when the dropdown element for the result tries to generate breadcrumbs.

> demo from #1333 
![377579749-e69208c1-333d-4819-9654-f4b3043f3c06](https://github.com/user-attachments/assets/80b8d14d-2b79-4a95-a01b-0f7f17b6efd9)


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #1333


## Additional Notes
I do want to mention that now that you can search for "hooks" without the page crashing, you can now get to the Hooks page for `v10` and the variant dropdown on there behaves a little weird since it can't map a the pages path to a version variant.
<img width="750" alt="image" src="https://github.com/user-attachments/assets/f3868222-24c8-4c6f-8212-0c390a7c55c7">

