### PR TITLE
Remove role="main" to ensure 'NPM Docs' page contains only one main landmark

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -35,7 +35,7 @@ const PageElement = ({element, props}) => {
       <PageProvider value={page}>
         <Box sx={{display: 'flex', flexDirection: 'column', minHeight: '100vh'}}>
           <Header />
-          <Box sx={{zIndex: 0, display: 'flex', flex: '1 1 auto', flexDirection: 'row'}} role="main">
+          <Box sx={{zIndex: 0, display: 'flex', flex: '1 1 auto', flexDirection: 'row'}}>
             <Box sx={{display: ['none', null, null, 'block']}}>
               <Sidebar />
             </Box>


### PR DESCRIPTION
<!-- What / Why -->

This pull request removes the `role="main"` attribute from the `PageElement` component in the `src/page.js` file to ensure there is only one main landmark on the 'NPM Docs' page.

## Before
<img width="1725" alt="NPM Docs page with more than one main landmark" src="https://github.com/user-attachments/assets/dd397661-24a0-489b-813e-638e028c6242">

## After
<img width="1711" alt="NPM Docs page with only one main landmark" src="https://github.com/user-attachments/assets/86d300a1-d11c-4f0d-80e1-781566b5c106">


## References

- https://github.com/github/accessibility-audits/issues/9212
