### PR TITLE
fix: v10 in dropdown

### DIFF
--- a/content/nav.yml
+++ b/content/nav.yml
@@ -1328,7 +1328,7 @@
       shortName: v10
       url: /cli/v10
       default: true
-      type: latest
+      type: legacy
       children:
         - title: CLI Commands
           shortName: Commands


### PR DESCRIPTION
v11 docs are up and this field was still left removing v10 in the dropdown