### PR TITLE
fix: drop cache for new majors

### DIFF
--- a/cli/lib/build.js
+++ b/cli/lib/build.js
@@ -113,6 +113,12 @@ const main = async ({loglevel, releases: rawReleases, useCurrent, navPath, conte
     }
   })
 
+  /**
+   * this voids the cache when a new version is added to release.json / not in the cli-cache.json
+   * this is done so that the previous major versions nav can be reset to legacy and pages can be droped from its variant
+   */
+  cache.voidOnNewKey(releases.map(v => v.id))
+
   const updates = await Promise.all(
     releases.map(r => extractRelease(r, {cache, contentPath, baseNav: navData, prerelease})),
   ).then(r => r.filter(Boolean))

--- a/cli/lib/build.js
+++ b/cli/lib/build.js
@@ -117,7 +117,7 @@ const main = async ({loglevel, releases: rawReleases, useCurrent, navPath, conte
    * this voids the cache when a new version is added to release.json / not in the cli-cache.json
    * this is done so that the previous major versions nav can be reset to legacy and pages can be droped from its variant
    */
-  cache.voidOnNewKey(releases.map(v => v.id))
+  cache?.voidOnNewKey(releases.map(v => v.id))
 
   const updates = await Promise.all(
     releases.map(r => extractRelease(r, {cache, contentPath, baseNav: navData, prerelease})),

--- a/cli/lib/cache.js
+++ b/cli/lib/cache.js
@@ -2,6 +2,8 @@ const fs = require('fs/promises')
 
 /** cache npm cli version shas to NOT pull down changes we already have */
 class CacheVersionSha {
+  shouldVoid = false
+
   constructor(cache, path) {
     this.cache = cache
     this.path = path
@@ -9,6 +11,16 @@ class CacheVersionSha {
 
   static async load(path) {
     return new CacheVersionSha(JSON.parse(await fs.readFile(path, 'utf-8')), path)
+  }
+
+  get keys() {
+    return Object.keys(this.cache)
+  }
+
+  voidOnNewKey(keys) {
+    if (keys.length !== this.keys.length || !keys.every(key => this.keys.includes(key))) {
+      this.shouldVoid = true
+    }
   }
 
   async save() {
@@ -22,6 +34,7 @@ class CacheVersionSha {
   }
 
   same(id, value) {
+    if (this.shouldVoid) return false
     return this.cache[id] === value
   }
 }


### PR DESCRIPTION
currently when new majors are introduced we need to shift around branches / older versions need to be rebuild, so we invalidate the cache here when a new major is introduced