### PR TITLE
Only break within words in `code`s

### DIFF
--- a/src/mdx/components.js
+++ b/src/mdx/components.js
@@ -179,7 +179,7 @@ export const UnorderedList = styled.ul`
     margin-bottom: 0;
   }
 
-  li {
+  li > code {
     word-break: break-all;
   }
 


### PR DESCRIPTION
In https://github.com/npm/documentation/issues/802, these `li`s were set to `word-break: break-all`, causing any word that's unfortunate enough to find itself at the end of a line to break at any arbitrary character. This was done to keep long words in `code` elements, like "`git+https://example.com/foo/bar#115311855adb0789a0466714ed48a1499ffea97e`", from overflowing the line box and the right margin. But we only want that behavior for `code`s, not for all text in the `li`.

## Screenshots

### Before

<https://docs.npmjs.com/package-name-guidelines>

![CleanShot 2025-02-24 at 14 59 13](https://github.com/user-attachments/assets/ddb15c41-f744-4517-8b70-2b5515b8a607)

<https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json>

![CleanShot 2025-02-24 at 15 03 46](https://github.com/user-attachments/assets/3e72a92e-c0a8-4222-909c-5c303bb7b912)



### After

<https://docs.npmjs.com/package-name-guidelines>

![CleanShot 2025-02-24 at 15 03 00](https://github.com/user-attachments/assets/e7a083f4-385e-431d-8259-95c3cbf9f0ff)

<https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json>

![CleanShot 2025-02-24 at 15 06 44](https://github.com/user-attachments/assets/675db746-a798-42ee-9564-09910da0aeb3)


## References

Related to #802
