### PR TITLE
docs(cli): replace proceeding with preceding in loglevels explanation

### DIFF
--- a/content/cli/v10/using-npm/logging.mdx
+++ b/content/cli/v10/using-npm/logging.mdx
@@ -44,7 +44,7 @@ The default value of `loglevel` is `"notice"` but there are several levels/types
 - `"verbose"`
 - `"silly"`
 
-All logs pertaining to a level proceeding the current setting will be shown.
+All logs pertaining to a level preceding the current setting will be shown.
 
 ##### Aliases
 

--- a/content/cli/v11/using-npm/logging.mdx
+++ b/content/cli/v11/using-npm/logging.mdx
@@ -50,7 +50,7 @@ The default value of `loglevel` is `"notice"` but there are several levels/types
 - `"verbose"`
 - `"silly"`
 
-All logs pertaining to a level proceeding the current setting will be shown.
+All logs pertaining to a level preceding the current setting will be shown.
 
 ##### Aliases
 

--- a/content/cli/v8/using-npm/logging.mdx
+++ b/content/cli/v8/using-npm/logging.mdx
@@ -43,7 +43,7 @@ The default value of `loglevel` is `"notice"` but there are several levels/types
 - `"verbose"`
 - `"silly"`
 
-All logs pertaining to a level proceeding the current setting will be shown.
+All logs pertaining to a level preceding the current setting will be shown.
 
 ##### Aliases
 

--- a/content/cli/v9/using-npm/logging.mdx
+++ b/content/cli/v9/using-npm/logging.mdx
@@ -44,7 +44,7 @@ The default value of `loglevel` is `"notice"` but there are several levels/types
 - `"verbose"`
 - `"silly"`
 
-All logs pertaining to a level proceeding the current setting will be shown.
+All logs pertaining to a level preceding the current setting will be shown.
 
 ##### Aliases
 


### PR DESCRIPTION
Grammar fix for the docs regarding the `loglevel` hierarchy in v8, v9, v10, and v11 CLI logging docs. 

## References

Closes #1505
