### PR TITLE
removing references to skimdb.npmjs.com

### DIFF
--- a/content/cli/v10/using-npm/registry.mdx
+++ b/content/cli/v10/using-npm/registry.mdx
@@ -21,8 +21,6 @@ You can configure npm to use any compatible registry you like, and even run your
 
 npm's package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.
 
-The npm public registry is powered by a CouchDB database, of which there is a public mirror at [https://skimdb.npmjs.com/registry](https://skimdb.npmjs.com/registry).
-
 The registry URL used is determined by the scope of the package (see [`scope`](/cli/v10/using-npm/scope). If no scope is specified, the default registry is used, which is supplied by the [`registry` config](/cli/v10/using-npm/config#registry) parameter. See [`npm config`](/cli/v10/commands/npm-config), [`npmrc`](/cli/v10/configuring-npm/npmrc), and [`config`](/cli/v10/using-npm/config) for more on managing npm's configuration. Authentication configuration such as auth tokens and certificates are configured specifically scoped to an individual registry. See [Auth Related Configuration](/cli/v10/configuring-npm/npmrc#auth-related-configuration)
 
 When the default registry is used in a package-lock or shrinkwrap it has the special meaning of "the currently configured registry". If you create a lock file while using the default registry you can switch to another registry and npm will install packages from the new registry, but if you create a lock file while using a custom registry packages will be installed from that registry even after you change to another registry.

--- a/content/cli/v11/using-npm/registry.mdx
+++ b/content/cli/v11/using-npm/registry.mdx
@@ -27,8 +27,6 @@ You can configure npm to use any compatible registry you like, and even run your
 
 npm's package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.
 
-The npm public registry is powered by a CouchDB database, of which there is a public mirror at [https://skimdb.npmjs.com/registry](https://skimdb.npmjs.com/registry).
-
 The registry URL used is determined by the scope of the package (see [`scope`](/cli/v11/using-npm/scope). If no scope is specified, the default registry is used, which is supplied by the [`registry` config](/cli/v11/using-npm/config#registry) parameter. See [`npm config`](/cli/v11/commands/npm-config), [`npmrc`](/cli/v11/configuring-npm/npmrc), and [`config`](/cli/v11/using-npm/config) for more on managing npm's configuration. Authentication configuration such as auth tokens and certificates are configured specifically scoped to an individual registry. See [Auth Related Configuration](/cli/v11/configuring-npm/npmrc#auth-related-configuration)
 
 When the default registry is used in a package-lock or shrinkwrap it has the special meaning of "the currently configured registry". If you create a lock file while using the default registry you can switch to another registry and npm will install packages from the new registry, but if you create a lock file while using a custom registry packages will be installed from that registry even after you change to another registry.

--- a/content/cli/v6/using-npm/registry.mdx
+++ b/content/cli/v6/using-npm/registry.mdx
@@ -21,8 +21,6 @@ You can configure npm to use any compatible registry you like, and even run your
 
 npm's package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.
 
-The npm public registry is powered by a CouchDB database, of which there is a public mirror at [https://skimdb.npmjs.com/registry](https://skimdb.npmjs.com/registry). The code for the couchapp is available at [https://github.com/npm/npm-registry-couchapp](https://github.com/npm/npm-registry-couchapp).
-
 The registry URL used is determined by the scope of the package (see [`scope`](/cli/v6/using-npm/scope). If no scope is specified, the default registry is used, which is supplied by the `registry` config parameter. See [`npm config`](/cli/v6/commands/npm-config), [`npmrc`](/cli/v6/configuring-npm/npmrc), and [`config`](/cli/v6/using-npm/config) for more on managing npm's configuration.
 
 ### Does npm send any information about me back to the registry?

--- a/content/cli/v7/using-npm/registry.mdx
+++ b/content/cli/v7/using-npm/registry.mdx
@@ -21,8 +21,6 @@ You can configure npm to use any compatible registry you like, and even run your
 
 npm's package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.
 
-The npm public registry is powered by a CouchDB database, of which there is a public mirror at [https://skimdb.npmjs.com/registry](https://skimdb.npmjs.com/registry).
-
 The registry URL used is determined by the scope of the package (see [`scope`](/cli/v7/using-npm/scope). If no scope is specified, the default registry is used, which is supplied by the `registry` config parameter. See [`npm config`](/cli/v7/commands/npm-config), [`npmrc`](/cli/v7/configuring-npm/npmrc), and [`config`](/cli/v7/using-npm/config) for more on managing npm's configuration.
 
 When the default registry is used in a package-lock or shrinkwrap is has the special meaning of "the currently configured registry". If you create a lock file while using the default registry you can switch to another registry and npm will install packages from the new registry, but if you create a lock file while using a custom registry packages will be installed from that registry even after you change to another registry.

--- a/content/cli/v8/using-npm/registry.mdx
+++ b/content/cli/v8/using-npm/registry.mdx
@@ -21,8 +21,6 @@ You can configure npm to use any compatible registry you like, and even run your
 
 npm's package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.
 
-The npm public registry is powered by a CouchDB database, of which there is a public mirror at [https://skimdb.npmjs.com/registry](https://skimdb.npmjs.com/registry).
-
 The registry URL used is determined by the scope of the package (see [`scope`](/cli/v8/using-npm/scope). If no scope is specified, the default registry is used, which is supplied by the `registry` config parameter. See [`npm config`](/cli/v8/commands/npm-config), [`npmrc`](/cli/v8/configuring-npm/npmrc), and [`config`](/cli/v8/using-npm/config) for more on managing npm's configuration.
 
 When the default registry is used in a package-lock or shrinkwrap is has the special meaning of "the currently configured registry". If you create a lock file while using the default registry you can switch to another registry and npm will install packages from the new registry, but if you create a lock file while using a custom registry packages will be installed from that registry even after you change to another registry.

--- a/content/cli/v9/using-npm/registry.mdx
+++ b/content/cli/v9/using-npm/registry.mdx
@@ -21,8 +21,6 @@ You can configure npm to use any compatible registry you like, and even run your
 
 npm's package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.
 
-The npm public registry is powered by a CouchDB database, of which there is a public mirror at [https://skimdb.npmjs.com/registry](https://skimdb.npmjs.com/registry).
-
 The registry URL used is determined by the scope of the package (see [`scope`](/cli/v9/using-npm/scope). If no scope is specified, the default registry is used, which is supplied by the [`registry` config](/cli/v9/using-npm/config#registry) parameter. See [`npm config`](/cli/v9/commands/npm-config), [`npmrc`](/cli/v9/configuring-npm/npmrc), and [`config`](/cli/v9/using-npm/config) for more on managing npm's configuration. Authentication configuration such as auth tokens and certificates are configured specifically scoped to an individual registry. See [Auth Related Configuration](/cli/v9/configuring-npm/npmrc#auth-related-configuration)
 
 When the default registry is used in a package-lock or shrinkwrap it has the special meaning of "the currently configured registry". If you create a lock file while using the default registry you can switch to another registry and npm will install packages from the new registry, but if you create a lock file while using a custom registry packages will be installed from that registry even after you change to another registry.


### PR DESCRIPTION
With the public communication of the replication feed changes, this PR updates all documentation to remove references to `skimdb.npmjs.com`. All requests will be redirected to `replicate.npmjs.com`.

## References
- Closes https://github.com/github/npm/issues/13321
- https://github.com/orgs/community/discussions/152515
- https://github.blog/changelog/2025-02-26-changes-and-deprecation-notice-for-npm-replication-apis/