### PR TITLE
feat: change "OS X" to be "macOS"

### DIFF
--- a/content/cli/v10/commands/npm-bugs.mdx
+++ b/content/cli/v10/commands/npm-bugs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's bug tracker UR
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v10/commands/npm-docs.mdx
+++ b/content/cli/v10/commands/npm-docs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's documentation 
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v10/commands/npm-fund.mdx
+++ b/content/cli/v10/commands/npm-fund.mdx
@@ -80,7 +80,7 @@ Not supported by all npm commands.
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v10/commands/npm-repo.mdx
+++ b/content/cli/v10/commands/npm-repo.mdx
@@ -33,7 +33,7 @@ This command tries to guess at the likely location of a package's repository URL
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v10/configuring-npm/install.mdx
+++ b/content/cli/v10/configuring-npm/install.mdx
@@ -41,9 +41,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 - [Node.js installer](https://nodejs.org/en/download/)
 - [NodeSource installer](https://github.com/nodesource/distributions). If you use Linux, we recommend that you use a NodeSource installer.
 
-#### OS X or Windows Node installers
+#### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 #### Linux or other operating systems Node installers
 

--- a/content/cli/v10/using-npm/config.mdx
+++ b/content/cli/v10/using-npm/config.mdx
@@ -182,7 +182,7 @@ Set to false to have it not do this. This can be used to work around the fact th
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v11/commands/npm-bugs.mdx
+++ b/content/cli/v11/commands/npm-bugs.mdx
@@ -51,7 +51,7 @@ This command tries to guess at the likely location of a package's bug tracker UR
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v11/commands/npm-docs.mdx
+++ b/content/cli/v11/commands/npm-docs.mdx
@@ -51,7 +51,7 @@ This command tries to guess at the likely location of a package's documentation 
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v11/commands/npm-fund.mdx
+++ b/content/cli/v11/commands/npm-fund.mdx
@@ -96,7 +96,7 @@ Not supported by all npm commands.
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v11/commands/npm-repo.mdx
+++ b/content/cli/v11/commands/npm-repo.mdx
@@ -49,7 +49,7 @@ This command tries to guess at the likely location of a package's repository URL
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v11/configuring-npm/install.mdx
+++ b/content/cli/v11/configuring-npm/install.mdx
@@ -47,9 +47,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 - [Node.js installer](https://nodejs.org/en/download/)
 - [NodeSource installer](https://github.com/nodesource/distributions). If you use Linux, we recommend that you use a NodeSource installer.
 
-#### OS X or Windows Node installers
+#### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 #### Linux or other operating systems Node installers
 

--- a/content/cli/v11/using-npm/config.mdx
+++ b/content/cli/v11/using-npm/config.mdx
@@ -188,7 +188,7 @@ Set to false to have it not do this. This can be used to work around the fact th
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v6/commands/npm-bugs.mdx
+++ b/content/cli/v6/commands/npm-bugs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's bug tracker UR
 
 #### browser
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: String
 
 The browser that is called by the `npm bugs` command to open websites.

--- a/content/cli/v6/commands/npm-docs.mdx
+++ b/content/cli/v6/commands/npm-docs.mdx
@@ -36,7 +36,7 @@ This command tries to guess at the likely location of a package's documentation 
 
 #### browser
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: String
 
 The browser that is called by the `npm docs` command to open websites.

--- a/content/cli/v6/commands/npm-fund.mdx
+++ b/content/cli/v6/commands/npm-fund.mdx
@@ -35,7 +35,7 @@ The list will avoid duplicated entries and will stack all packages that share th
 
 #### browser
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: String
 
 The browser that is called by the `npm fund` command to open websites.

--- a/content/cli/v6/commands/npm-repo.mdx
+++ b/content/cli/v6/commands/npm-repo.mdx
@@ -33,7 +33,7 @@ This command tries to guess at the likely location of a package's repository URL
 
 #### browser
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: String
 
 The browser that is called by the `npm repo` command to open websites.

--- a/content/cli/v6/configuring-npm/install.mdx
+++ b/content/cli/v6/configuring-npm/install.mdx
@@ -51,9 +51,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 - [Node.js installer](https://nodejs.org/en/download/)
 - [NodeSource installer](https://github.com/nodesource/distributions). If you use Linux, we recommend that you use a NodeSource installer.
 
-#### OS X or Windows Node installers
+#### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 #### Linux or other operating systems Node installers
 

--- a/content/cli/v6/using-npm/config.mdx
+++ b/content/cli/v6/using-npm/config.mdx
@@ -185,7 +185,7 @@ Set to false to have it not do this. This can be used to work around the fact th
 
 #### browser
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: String
 
 The browser that is called by the `npm docs` command to open websites.

--- a/content/cli/v7/commands/npm-bugs.mdx
+++ b/content/cli/v7/commands/npm-bugs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's bug tracker UR
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v7/commands/npm-docs.mdx
+++ b/content/cli/v7/commands/npm-docs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's documentation 
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v7/commands/npm-fund.mdx
+++ b/content/cli/v7/commands/npm-fund.mdx
@@ -81,7 +81,7 @@ Not supported by all npm commands.
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v7/commands/npm-repo.mdx
+++ b/content/cli/v7/commands/npm-repo.mdx
@@ -33,7 +33,7 @@ This command tries to guess at the likely location of a package's repository URL
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v7/configuring-npm/install.mdx
+++ b/content/cli/v7/configuring-npm/install.mdx
@@ -51,9 +51,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 - [Node.js installer](https://nodejs.org/en/download/)
 - [NodeSource installer](https://github.com/nodesource/distributions). If you use Linux, we recommend that you use a NodeSource installer.
 
-#### OS X or Windows Node installers
+#### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 #### Linux or other operating systems Node installers
 

--- a/content/cli/v7/using-npm/config.mdx
+++ b/content/cli/v7/using-npm/config.mdx
@@ -170,7 +170,7 @@ Set to false to have it not do this. This can be used to work around the fact th
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v8/commands/npm-bugs.mdx
+++ b/content/cli/v8/commands/npm-bugs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's bug tracker UR
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v8/commands/npm-docs.mdx
+++ b/content/cli/v8/commands/npm-docs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's documentation 
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v8/commands/npm-fund.mdx
+++ b/content/cli/v8/commands/npm-fund.mdx
@@ -80,7 +80,7 @@ Not supported by all npm commands.
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v8/commands/npm-repo.mdx
+++ b/content/cli/v8/commands/npm-repo.mdx
@@ -33,7 +33,7 @@ This command tries to guess at the likely location of a package's repository URL
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v8/configuring-npm/install.mdx
+++ b/content/cli/v8/configuring-npm/install.mdx
@@ -51,9 +51,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 - [Node.js installer](https://nodejs.org/en/download/)
 - [NodeSource installer](https://github.com/nodesource/distributions). If you use Linux, we recommend that you use a NodeSource installer.
 
-#### OS X or Windows Node installers
+#### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 #### Linux or other operating systems Node installers
 

--- a/content/cli/v8/using-npm/config.mdx
+++ b/content/cli/v8/using-npm/config.mdx
@@ -180,7 +180,7 @@ Set to false to have it not do this. This can be used to work around the fact th
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v9/commands/npm-bugs.mdx
+++ b/content/cli/v9/commands/npm-bugs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's bug tracker UR
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v9/commands/npm-docs.mdx
+++ b/content/cli/v9/commands/npm-docs.mdx
@@ -35,7 +35,7 @@ This command tries to guess at the likely location of a package's documentation 
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v9/commands/npm-fund.mdx
+++ b/content/cli/v9/commands/npm-fund.mdx
@@ -80,7 +80,7 @@ Not supported by all npm commands.
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v9/commands/npm-repo.mdx
+++ b/content/cli/v9/commands/npm-repo.mdx
@@ -33,7 +33,7 @@ This command tries to guess at the likely location of a package's repository URL
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/cli/v9/configuring-npm/install.mdx
+++ b/content/cli/v9/configuring-npm/install.mdx
@@ -41,9 +41,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 - [Node.js installer](https://nodejs.org/en/download/)
 - [NodeSource installer](https://github.com/nodesource/distributions). If you use Linux, we recommend that you use a NodeSource installer.
 
-#### OS X or Windows Node installers
+#### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 #### Linux or other operating systems Node installers
 

--- a/content/cli/v9/using-npm/config.mdx
+++ b/content/cli/v9/using-npm/config.mdx
@@ -180,7 +180,7 @@ Set to false to have it not do this. This can be used to work around the fact th
 
 #### `browser`
 
-- Default: OS X: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
+- Default: macOS: `"open"`, Windows: `"start"`, Others: `"xdg-open"`
 - Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/content/getting-started/configuring-your-local-environment/downloading-and-installing-node-js-and-npm.mdx
+++ b/content/getting-started/configuring-your-local-environment/downloading-and-installing-node-js-and-npm.mdx
@@ -54,9 +54,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 
 If you use Linux, we recommend that you use a NodeSource installer.
 
-### OS X or Windows Node installers
+### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 ### Linux or other operating systems Node installers
 

--- a/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
+++ b/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
@@ -12,7 +12,7 @@ npm -v
 
 ## Upgrading on `*nix` (OSX, Linux, etc.)
 
-_(You may need to prefix these commands with `sudo`, especially on Linux, or OS X if you installed Node using its default installer.)_
+_(You may need to prefix these commands with `sudo`, especially on Linux, or macOS if you installed Node using its default installer.)_
 
 You can upgrade to the latest version of npm using:
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR updates the documentation to replace outdated references to "OS X" with the current naming convention, "macOS", for consistency and clarity.

### Changes Made

- Replaced all instances of "OS X" with "macOS" in the npm documentation files.

### Checklist

- [x] Terminology is updated consistently
- [x] No content or meaning changes outside of name update
- [x] Docs reflect current macOS branding

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #1459 