### PR TITLE
owlstronaut/deps updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "postcss-preset-env": "^10.1.1",
         "prism-react-renderer": "^2.3.1",
         "prismjs": "^1.30.0",
-        "react": "^18.2.0",
+        "react": "^19.1.0",
         "react-addons-text-content": "^0.0.4",
         "react-dom": "^18.2.0",
         "react-focus-on": "^3.9.1",
@@ -10879,6 +10879,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@tapjs/reporter/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@tapjs/reporter/node_modules/string-length": {
@@ -38521,13 +38534,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "postcss-preset-env": "^10.1.1",
     "prism-react-renderer": "^2.3.1",
     "prismjs": "^1.30.0",
-    "react": "^18.2.0",
+    "react": "^19.1.0",
     "react-addons-text-content": "^0.0.4",
     "react-dom": "^18.2.0",
     "react-focus-on": "^3.9.1",

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import {Link as PrimerLink} from '@primer/react'
-import {Link as GatsbyLink} from 'gatsby'
 import omit from '../util/omit'
 
 const FALLBACK = `http://_${Math.random().toString().slice(2)}._${Math.random().toString().slice(2)}`
@@ -22,15 +21,26 @@ const getLocalPath = href => {
   return null
 }
 
-const GatsbyLinkWithoutSxProps = React.forwardRef(function GatsbyLinkWithoutSxProps(props, ref) {
-  return <GatsbyLink ref={ref} {...omit(props, 'sx', 'underline', 'hoverColor', 'muted')} />
+const BasicLinkAdapter = React.forwardRef(function BasicLinkAdapter(props, ref) {
+  const { to, ...otherProps } = props
+  // Convert 'to' prop to 'href' for regular anchor tags
+  return (
+    <a
+      ref={ref}
+      href={to}
+      {...omit(otherProps, 'sx', 'underline', 'hoverColor', 'muted')}
+      aria-label={otherProps['aria-label'] || 'Link'}
+    >
+      {props.children || 'Link'}
+    </a>
+  )
 })
 
 const Link = React.forwardRef(function Link({to, href, ...props}, ref) {
   const localPath = getLocalPath(href)
 
   if (to || localPath !== null) {
-    return <PrimerLink ref={ref} as={GatsbyLinkWithoutSxProps} to={to || localPath} {...props} />
+    return <PrimerLink ref={ref} as={BasicLinkAdapter} to={to || localPath} {...props} />
   }
 
   return <PrimerLink ref={ref} href={href} {...props} />


### PR DESCRIPTION
- **deps: bump react-dom from 18.3.1 to 19.1.0**
- **deps: bump react from 18.3.1 to 19.1.0**
- **chore: make link use a basic anchor tag instead of Gatsby**
