### PR TITLE
docs: update note to mention yarn v4.9.0 supporting provenance

### DIFF
--- a/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
+++ b/content/packages-and-modules/securing-your-code/generating-provenance-statements.mdx
@@ -121,7 +121,7 @@ If you publish your packages with tools that do not directly invoke the `npm pub
 
 <Note>
 
-**Note:** At this time, `yarn` is not a supported tool for publishing your packages with provenance.
+**Note:** To publish packages with provenance using Yarn, [v4.9.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.9.0) or greater is required.
 
 </Note>
 


### PR DESCRIPTION
As of today, Yarn released [v4.9.0](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.9.0), which adds support for publishing to NPM with provenance statements.

Therefore, I have updated the note about Yarn to include such. I do, however, apologise if there are better ways to word the sentence.