### PR TITLE
docs: clarify token creation in npm login command

### DIFF
--- a/content/cli/v11/commands/npm-login.mdx
+++ b/content/cli/v11/commands/npm-login.mdx
@@ -47,6 +47,8 @@ Note: This command is unaware of workspaces.
 
 Verify a user in the specified registry, and save the credentials to the `.npmrc` file. If no registry is specified, the default registry will be used (see [`config`](/cli/v11/using-npm/config)).
 
+When you run `npm login`, the CLI automatically generates a legacy token of publish type. For more information, see [About legacy tokens](/about-access-tokens#about-legacy-tokens).
+
 When using `legacy` for your `auth-type`, the username and password, are read in from prompts.
 
 To reset your password, go to [https://www.npmjs.com/forgot](https://www.npmjs.com/forgot)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This is simple PR for adjust `npm login` doc.

### Problem Description:

When using `npm login`, users are not aware that this command generates a legacy token with publish permissions. This information is not evident in the `npm login` cli documentation.

After a while searching. found that this context and detail hiding in the [About legacy tokens](https://docs.npmjs.com/about-access-tokens#about-legacy-tokens) documentation. 

### Solution:
Add a clear description in the `npm login` documentation in this PR so that users can understand publish token would be created after `npm login` in the future.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
