### PR TITLE
Revert "deps: bump the dependency-updates group across 1 directory with 4 updates"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9748,9 +9748,9 @@
       "license": "MIT"
     },
     "node_modules/@primer/react": {
-      "version": "37.22.0",
-      "resolved": "https://registry.npmjs.org/@primer/react/-/react-37.22.0.tgz",
-      "integrity": "sha512-DB/EYTx5A8OctihvjZhK/h/0GUmqooMHoE4a5bl91Rcq8z2+vwPmi/ldZ1ACoClg7ePhLgZzPTGliYKBE2zk9w==",
+      "version": "37.21.0",
+      "resolved": "https://registry.npmjs.org/@primer/react/-/react-37.21.0.tgz",
+      "integrity": "sha512-ZKAAY905Tugdoc+Z6EKwp0jcfdFJ10DCBz3pj8Fbk4Cu9YOdnlpGCnvItgxpsaJwtU8gSFjnWs5C0i/JjO8WIQ==",
       "license": "MIT",
       "dependencies": {
         "@github/relative-time-element": "^4.4.5",
@@ -9776,7 +9776,7 @@
         "hsluv": "1.0.1",
         "lodash.isempty": "^4.4.0",
         "lodash.isobject": "^3.0.2",
-        "react-intersection-observer": "^9.16.0",
+        "react-intersection-observer": "^9.4.3",
         "react-is": "^18.2.0",
         "styled-system": "^5.1.5",
         "type-check": "0.4.0"
@@ -19074,9 +19074,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.3.tgz",
-      "integrity": "sha512-vDo4d9yQE+cS2tdIT4J02H/16veRvkHgiLDRpej+WL67oCfbOb97itZXn8wMPJ/GsiEBVjrjs//AVNw2Cp1EcA==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
+      "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -20288,9 +20288,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
-      "integrity": "sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.3.1.tgz",
+      "integrity": "sha512-vad9VWgEm9xaVXRNmb4aeOt0PWDc61IAdzghkbYQ2wavgax148iKoX1rNJcgkBGCipzLzOnHYVgL7xudM9yccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22712,12 +22712,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.10.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.10.1.tgz",
-      "integrity": "sha512-g+fANUVC17SzQc6eA0CtomBW4n67ckhS2hq5fjkKZneKzv7sbdXK3zzjnnAKB22Ck+Qhh+IlO5RjHNKULsq99Q==",
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.9.4.tgz",
+      "integrity": "sha512-yaeGDmGQ3eCQEwZ95/pRQMaSh/Q4E2CK6JYOclG/PdjyQad0MULJ+JFVV8911Fl5a6tF6o0wgW8Dpl5Qx4Adjg==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.10.1",
+        "motion-dom": "^12.9.4",
         "motion-utils": "^12.9.4",
         "tslib": "^2.4.0"
       },
@@ -34056,9 +34056,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.10.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.10.1.tgz",
-      "integrity": "sha512-rY8DNqgKh4LeFSQBkuXpe/7sycYS9RM+4luukjHpHogF1liSvIp0Hedx0q2QsWNz+AHuZ5bZQ9j9QZSUCA8bbw==",
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.9.4.tgz",
+      "integrity": "sha512-25TWkQPj5I18m+qVjXGtCsxboY11DaRC5HMjd29tHKExazW4Zf4XtAagBdLpyKsVuAxEQ6cx5/E4AB21PFpLnQ==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.9.4"
@@ -38826,9 +38826,9 @@
       }
     },
     "node_modules/react-intersection-observer": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
-      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.14.0.tgz",
+      "integrity": "sha512-AYqlmDZn85VUmlODwYym9y5OlqY2cFyIu41dkN0GJWvhdbd19Mh16mz5IH6fO1gp5V4FfQOO4m0zGc04Tj13rQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",


### PR DESCRIPTION
Reverts npm/documentation#1576

### Issues

#### Transparent menus

![Overlapping text in a transparent menu](https://github.com/user-attachments/assets/61546c9d-47e9-4975-aced-b524dcfd86ab)

#### Search text not visible

I typed "install", but it's not visible

![Search results without a visible search term](https://github.com/user-attachments/assets/24064930-d3c3-4028-833d-d2312caeaf45)



