### PR TITLE
fix: v11 npm run page not found

### DIFF
--- a/content/cli/v11/commands/npm-run-script.mdx
+++ b/content/cli/v11/commands/npm-run-script.mdx
@@ -30,6 +30,7 @@ redirect_from:
   - /cli/v11/cli-commands/run-script
   - /cli/v11/commands/run-script
   - /cli/v11/npm-run-script
+  - /cli/v11/commands/npm-run
   - /cli/v11/run-script
   - /commands/npm-run-script
   - /commands/run-script

--- a/content/nav.yml
+++ b/content/nav.yml
@@ -1743,7 +1743,7 @@
               url: /cli/v11/commands/npm-root
               description: Display npm root
             - title: npm run
-              url: /cli/v11/commands/npm-run
+              url: /cli/v11/commands/npm-run-script
               description: Run arbitrary package scripts
             - title: npm sbom
               url: /cli/v11/commands/npm-sbom


### PR DESCRIPTION
Page for "npm run" in v11 not found.
https://docs.npmjs.com/cli/v11/commands/npm-run not found, judging from content/nav.yml all previous version points to /npm-run-script but for some reason the v11 version points to /npm-run.
