### PR TITLE
Restore an old link from policies using redirect

### DIFF
--- a/cli/lib/redirects.js
+++ b/cli/lib/redirects.js
@@ -60,4 +60,7 @@ module.exports = {
   'using-npm/scope': ({section}) => [join(section, 'npm-scope')],
   'about-pgp-signatures-for-packages-in-the-public-registry': () => ['/about-registry-signatures'],
   'verifying-the-pgp-signature-for-a-package-from-the-npm-public-registry': () => ['/verifying-registry-signatures'],
+
+  // policies
+  'policies/trademark': () => ['policies/logos-and-usage'],
 }


### PR DESCRIPTION
The logos and usage policies page pretty much have contents from the [trademark page](https://web.archive.org/web/20220315191357/https://docs.npmjs.com/policies/trademark) that moved back in 2022/2023.

As the previous link is still around, this redirect should function better than a 404.

