### PR TITLE
Redirect policies/trademark to logos and usage page

### DIFF
--- a/content/policies/logos-and-usage.mdx
+++ b/content/policies/logos-and-usage.mdx
@@ -1,6 +1,8 @@
 ---
 title: npm Logos and Usage
 edit_on_github: false
+redirect_from:
+  - /policies/trademark
 ---
 
 This policy describes npm logos and trademarks and how you may use them. For information on what to do if someone infringes a trademark of _yours_ with a confusing package name, see the [Disputes policy][disputes].

--- a/content/policies/logos-and-usage.mdx
+++ b/content/policies/logos-and-usage.mdx
@@ -2,7 +2,7 @@
 title: npm Logos and Usage
 edit_on_github: false
 redirect_from:
-  - /policies/trademark
+  - /policies/trademark/
 ---
 
 This policy describes npm logos and trademarks and how you may use them. For information on what to do if someone infringes a trademark of _yours_ with a confusing package name, see the [Disputes policy][disputes].


### PR DESCRIPTION
This redirect restores an old link from trademark policies to our logos and usages page.

The logos and usage policies page pretty much have contents from the trademark page that moved back in 2022/2023.

As the previous link is still around, this redirect should function better than a 404.

## References

Supersedes #1587 