### PR TITLE
Update outdated docker build secrets URL

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
+++ b/content/integrations/integrating-npm-with-external-services/docker-and-private-modules.mdx
@@ -4,7 +4,7 @@ redirect_from:
   - /private-modules/docker-and-private-modules
 ---
 
-To install private npm packages in a Docker container, you will need to use [Docker build secrets](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information).
+To install private npm packages in a Docker container, you will need to use [Docker build secrets](https://docs.docker.com/build/building/secrets/#types-of-build-secrets).
 
 ## Background: runtime variables
 


### PR DESCRIPTION

## Description:

Update outdated `Docker Build Secrets` URL

- Old URL: https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information
- New URL: https://docs.docker.com/build/building/secrets/#types-of-build-secrets

## References:

Closes #594 

