### PR TITLE
docs: added type field in the documentation of package.json

### DIFF
--- a/content/cli/v11/configuring-npm/package-json.mdx
+++ b/content/cli/v11/configuring-npm/package-json.mdx
@@ -305,6 +305,39 @@ These can not be included.
 
 The "exports" provides a modern alternative to "main" allowing multiple entry points to be defined, conditional entry resolution support between environments, and preventing any other entry points besides those defined in "exports". This encapsulation allows module authors to clearly define the public interface for their package. For more details see the [node.js documentation on package entry points](https://nodejs.org/api/packages.html#package-entry-points)
 
+### type
+
+The `type` field defines the module format that Node.js should use for `.js` files in the package. When set to `"module"`, Node.js will treat `.js` files as ES modules. When set to `"commonjs"` (or when the field is omitted), Node.js will treat `.js` files as CommonJS modules.
+
+```json
+{
+  "type": "module"
+}
+```
+
+```json
+{
+  "type": "commonjs"
+}
+```
+
+When `"type": "module"` is set:
+- `.js` files are parsed as ES modules
+- `.mjs` files are always parsed as ES modules
+- `.cjs` files are always parsed as CommonJS modules
+- You can use `import` and `export` statements in `.js` files
+- Top-level `await` is supported
+
+When `"type": "commonjs"` is set (or omitted):
+- `.js` files are parsed as CommonJS modules
+- `.mjs` files are always parsed as ES modules  
+- `.cjs` files are always parsed as CommonJS modules
+- You use `require()` and `module.exports` in `.js` files
+
+This field applies to the entire package and all its subdirectories, unless overridden by a `package.json` file in a subdirectory.
+
+For more details, see the [Node.js documentation on package.json type field](https://nodejs.org/api/packages.html#type).
+
 ### main
 
 The main field is a module ID that is the primary entry point to your program. That is, if your package is named `foo`, and a user installs it, and then does `require("foo")`, then your main module's exports object will be returned.


### PR DESCRIPTION



# Add documentation for package.json `type` field

## What / Why

This PR adds comprehensive documentation for the `type` field in package.json, which was previously undocumented in the npm CLI documentation. The `type` field is an important Node.js feature that determines how `.js` files are interpreted (as ES modules or CommonJS modules) and was missing from the official npm package.json documentation.

### Changes made:
- Added complete documentation for the `type` field between the `exports` and `main` sections
- Included practical JSON examples for both `"module"` and `"commonjs"` values
- Explained the behavior and implications of each type setting
- Added details about file extension handling (`.js`, `.mjs`, `.cjs`)
- Added reference to official Node.js documentation for additional details

This addition helps developers understand how to properly configure their packages for ES modules or CommonJS, which is crucial for modern Node.js development.

## References

Fixes npm/cli#[8376] - Documents the missing `type` field in package.json