### PR TITLE
docs(npm-install): add documentation for --legacy-peer-deps flag

### DIFF
--- a/content/cli/v11/commands/npm-install.mdx
+++ b/content/cli/v11/commands/npm-install.mdx
@@ -415,6 +415,17 @@ By default, conflicting `peerDependencies` deep in the dependency graph will be 
 
 When such an override is performed, a warning is printed, explaining the conflict and the packages involved. If `--strict-peer-deps` is set, then this warning is treated as a failure.
 
+#### `legacy-peer-deps`
+
+- Default: false
+- Type: Boolean
+
+When set to `true`, npm completely ignores peerDependencies when building the dependency tree, behaving as it did in npm versions 3 through 6.
+
+This option can help resolve installation issues if a package cannot be installed due to strict or conflicting peerDependencies. Enabling this setting bypasses the stricter peer dependency resolution introduced in npm v7+ and falls back to the older, more permissive algorithm.
+
+> **Note**: Using legacy-peer-deps may result in a dependency tree that does not correctly reflect the intended peer relationships, potentially leading to runtime issues. Use with caution.
+
 #### `prefer-dedupe`
 
 - Default: false


### PR DESCRIPTION
## Add documentation for `--legacy-peer-deps` flag

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR adds documentation for the `--legacy-peer-deps` option in the `npm install` command.


## Changes Made: 
- Added a new section documenting for`--legacy-peer-deps` option in `content/cli/v11/commands/npm-install.mdx`
- Explained what the flag does and when it might be useful
- Included warnings about the potential risks of using the option


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes: [[DOCS] --legacy-peer-deps field is undocumented in the documentation of npm #8408](https://github.com/npm/cli/issues/8408)