### PR TITLE
Update about-semantic-versioning.mdx to clarify version resolution and pre-releases

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/about-semantic-versioning.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/about-semantic-versioning.mdx
@@ -35,6 +35,12 @@ For example, to specify acceptable version ranges up to 1.0.4, use the following
 
 For more information on semantic versioning syntax, see the [npm semver calculator][semver-calc].
 
+<Note>
+
+**Note:** When using version ranges in your `package.json`, npm resolves to the **highest available version** that satisfies the specified constraints. This behavior ensures that consumers automatically receive the most recent compatible stable release, as long as the changes remain within the defined semver range. Pre-release versions (e.g., `1.2.0-beta.1`) are ignored unless explicitly requested or allowed via specific configuration.
+
+</Note>
+
 ### Example
 
 ```json


### PR DESCRIPTION
This pull request adds a note to the "About semantic versioning" guide to clarify how npm resolves versions within defined ranges in `package.json`. It specifies that npm installs the highest compatible **stable** version and ignores pre-releases like `1.2.0-beta.1` unless explicitly allowed by configuration.

The goal is to help developers better understand version behavior and prevent unexpected installations when using semver constraints.

## References
None
