### PR TITLE
fix(docs): update VariantItem link implementation and separate CLI version docs  Closes npm/cli#8414

### DIFF
--- a/src/components/variant-select.js
+++ b/src/components/variant-select.js
@@ -16,13 +16,10 @@ const StyledOverlay = styled(ActionMenu.Overlay)`
 
 const VariantItem = ({title, shortName, url, active}) => {
   return (
-    <ActionList.Item state= {{scrollUpdate: false}} id={shortName} active={active}>
-      <LinkNoUnderline 
-        to={url}
-      >
-        {title}
-      </LinkNoUnderline>
-  </ActionList.Item>)
+    <ActionList.Item state={{scrollUpdate: false}} id={shortName} active={active}>
+      <LinkNoUnderline to={url}>{title}</LinkNoUnderline>
+    </ActionList.Item>
+  )
 }
 
 const useVariantFocus = () => {
@@ -42,6 +39,13 @@ const VariantMenu = ({title, latest, current, prerelease, legacy}) => {
   const [open, setOpen] = React.useState(false)
   const anchorRef = useVariantFocus()
   const labelId = 'label-versions-list-item'
+  const locationChange = useLocationChange()
+
+  React.useEffect(() => {
+    if (locationChange.change && getNav.didVariantChange(locationChange.previous, locationChange.current)) {
+      setOpen(false)
+    }
+  }, [locationChange.change, locationChange.current, locationChange.previous])
 
   return (
     <>

--- a/src/components/variant-select.js
+++ b/src/components/variant-select.js
@@ -14,11 +14,16 @@ const StyledOverlay = styled(ActionMenu.Overlay)`
   box-shadow: var(--shadow-resting-medium, 0 3px 6px rgba(140, 149, 159, 0.15));
 `
 
-const VariantItem = ({title, shortName, url, active}) => (
-  <ActionList.Item as={LinkNoUnderline} to={url} state={{scrollUpdate: false}} id={shortName} active={active}>
-    {title}
-  </ActionList.Item>
-)
+const VariantItem = ({title, shortName, url, active}) => {
+  return (
+    <ActionList.Item state= {{scrollUpdate: false}} id={shortName} active={active}>
+      <LinkNoUnderline 
+        to={url}
+      >
+        {title}
+      </LinkNoUnderline>
+  </ActionList.Item>)
+}
 
 const useVariantFocus = () => {
   const locationChange = useLocationChange()


### PR DESCRIPTION


<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
## Description
This PR addresses [npm/cli#8414](https://github.com/npm/cli/issues/8414), which reports that switching versions using the CLI version dropdown does not properly update the displayed documentation.

### Changes
- **Refactored `VariantItem` component**:

These changes ensure that when users switch CLI versions from the dropdown, the documentation updates correctly to display the appropriate content for each version.

---

## Updated

https://github.com/user-attachments/assets/8668e308-ac8d-4f09-b6f4-0ddafa67d317


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes npm/cli#8414
