### PR TITLE
docs: add docs for package.json/type

### DIFF
--- a/content/cli/v11/configuring-npm/package-json.mdx
+++ b/content/cli/v11/configuring-npm/package-json.mdx
@@ -305,6 +305,12 @@ These can not be included.
 
 The "exports" provides a modern alternative to "main" allowing multiple entry points to be defined, conditional entry resolution support between environments, and preventing any other entry points besides those defined in "exports". This encapsulation allows module authors to clearly define the public interface for their package. For more details see the [node.js documentation on package entry points](https://nodejs.org/api/packages.html#package-entry-points)
 
+### type
+
+The `type` field defines the module format that Node.js should use for `.js` files in the package.
+
+For more details, see the [Node.js documentation](https://nodejs.org/api/packages.html#type).
+
 ### main
 
 The main field is a module ID that is the primary entry point to your program. That is, if your package is named `foo`, and a user installs it, and then does `require("foo")`, then your main module's exports object will be returned.


### PR DESCRIPTION
This PR adds comprehensive documentation for the type field in package.json

## References
  Closes #1204
