### PR TITLE
docs: rebrand OS X and OSX references to macOS

### DIFF
--- a/content/getting-started/configuring-your-local-environment/downloading-and-installing-node-js-and-npm.mdx
+++ b/content/getting-started/configuring-your-local-environment/downloading-and-installing-node-js-and-npm.mdx
@@ -35,7 +35,7 @@ npm -v
 
 Node version managers allow you to install and switch between multiple versions of Node.js and npm on your system so you can test your applications on multiple versions of npm to ensure they work for users on different versions.
 
-### OSX or Linux Node version managers
+### macOS or Linux Node version managers
 
 - [nvm](https://github.com/creationix/nvm)
 - [n](https://github.com/tj/n)
@@ -54,9 +54,9 @@ If you are unable to use a Node version manager, you can use a Node installer to
 
 If you use Linux, we recommend that you use a NodeSource installer.
 
-### OS X or Windows Node installers
+### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
+If you're using macOS or Windows, use one of the installers from the [Node.js download page](https://nodejs.org/en/download/). Be sure to install the version labeled **LTS**. Other versions have not yet been tested with npm.
 
 ### Linux or other operating systems Node installers
 

--- a/content/getting-started/troubleshooting/try-the-latest-stable-version-of-node.mdx
+++ b/content/getting-started/troubleshooting/try-the-latest-stable-version-of-node.mdx
@@ -20,7 +20,7 @@ For some Linux distributions (Debian/Ubuntu and RedHat/CentOS), the latest node 
 
 Install the latest msi from [https://nodejs.org/en/download](https://nodejs.org/en/download)
 
-### Updating node on OSX
+### Updating node on macOS
 
 Install the latest package from [https://nodejs.org/en/download](https://nodejs.org/en/download)
 

--- a/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
+++ b/content/getting-started/troubleshooting/try-the-latest-stable-version-of-npm.mdx
@@ -10,9 +10,9 @@ redirect_from:
 npm -v
 ```
 
-## Upgrading on `*nix` (OSX, Linux, etc.)
+## Upgrading on `*nix` (macOS, Linux, etc.)
 
-_(You may need to prefix these commands with `sudo`, especially on Linux, or OS X if you installed Node using its default installer.)_
+_(You may need to prefix these commands with `sudo`, especially on Linux, or macOS if you installed Node using its default installer.)_
 
 You can upgrade to the latest version of npm using:
 

--- a/content/packages-and-modules/getting-packages-from-the-registry/uninstalling-packages-and-dependencies.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/uninstalling-packages-and-dependencies.mdx
@@ -58,7 +58,7 @@ npm uninstall --no-save lodash
 
 To confirm that `npm uninstall` worked correctly, check that the `node_modules` directory no longer contains a directory for the uninstalled package(s).
 
-- Unix system (such as OSX): `ls node_modules`
+- Unix system (such as macOS): `ls node_modules`
 - Windows systems: `dir node_modules`
 
 ## Uninstalling global packages


### PR DESCRIPTION
## Situation

Several website pages on https://docs.npmjs.com, such as https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

refer to the operating system "OS X" and "OSX".

The last version of OS X was OS X 10.11 (El Capitan), released on Sep 30, 2015.

Apple rebranded to macOS with the macOS 10.12 (Sierra) release on Sep 30, 2016.

## Change

Rename "OS X" and "OSX" to "macOS".

## References

https://en.wikipedia.org/wiki/MacOS_version_history
https://www.apple.com/macos/

Related to https://github.com/npm/documentation/issues/1459
Follows on from https://github.com/npm/cli/pull/8371 which only changed the branding in the CLI v11 documentation content, such as https://docs.npmjs.com/cli/v11/configuring-npm/install, not in non-CLI website content.
