### PR TITLE
fix: shell command syntax

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
@@ -37,7 +37,7 @@ To minimize the chance of permissions errors, you can configure npm to use a dif
 3. Configure npm to use the new directory path:
 
    ```
-   npm config set prefix '~/.npm-global'
+   npm config set prefix ~/.npm-global
    ```
 
 4. In your preferred text editor, open or create a `~/.profile` file and add this line:


### PR DESCRIPTION
## Problem
I followed the instructions and got this error when running an NPM package globally:
```
Path "/Users/me/~/.npm-global/lib/node_modules" does not exist.
Please check the NODE_PATH environment variable.
```

In `.npmrc` the prefix was set to:
```
prefix=~/.npm-global
```

`~` is not expanded here so NPM looks for a literal `~/` path instead of the home directory.

## Solution
Use the absolute path instead:
```
prefix=/Users/me/.npm-global
```

Run `npm config` without quotes around the path so that `~` is properly expanded.