### PR TITLE
Fix dependabot 14082

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21041,18 +21041,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
@@ -34052,15 +34040,6 @@
       "integrity": "sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==",
       "license": "MIT"
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -42517,9 +42496,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
-      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -99,6 +99,9 @@
     "jest-environment-jsdom": "^30.0.0",
     "prettier": "^3.1.1"
   },
+  "overrides": {
+    "tmp": "^0.2.5"
+  },
   "author": "GitHub Inc.",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
### What approach did you choose and why?

- Overrides the `tmp` version `0.2.5` manually in `package.json` to fix the dependabot alert.

### Risk Assessment


- **Low risk** changes are small, highly observable, and easily rolled back.


### References

- https://github.com/github/npm/issues/14082
