### PR TITLE
fix: gitlab example for trusted publishing

### DIFF
--- a/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
+++ b/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
@@ -118,10 +118,6 @@ stages:
 variables:
   NODE_VERSION: '20'
 
-id_tokens:
-  NPM_ID_TOKEN:
-    aud: "npm:registry.npmjs.org"
-
 test:
   stage: test
   image: node:${NODE_VERSION}
@@ -132,6 +128,9 @@ test:
 publish:
   stage: publish
   image: node:${NODE_VERSION}
+  id_tokens:
+    NPM_ID_TOKEN:
+      aud: "npm:registry.npmjs.org"
   script:
     # Ensure npm 11.5.1 or later is installed
     - npm install -g npm@latest


### PR DESCRIPTION
I haven't been quite able to make trusted publishing work in GitLab (see https://github.com/npm/cli/issues/8558), but I do think the example is incorrect. `id_tokens` is not a valid global keyword. It needs to be specified under `default` or a job. I think a job makes more sense.

Reference:
* https://docs.gitlab.com/ci/yaml/#global-keywords
* https://docs.gitlab.com/ci/yaml/#default
* https://docs.gitlab.com/ci/yaml/#id_tokens