### PR TITLE
docs: improve documentation on resolving EACCES

### DIFF
--- a/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
+++ b/content/packages-and-modules/getting-packages-from-the-registry/resolving-eacces-permissions-errors-when-installing-packages-globally.mdx
@@ -24,45 +24,43 @@ This is the best way to avoid permissions issues. To reinstall npm with a node v
 
 </Note>
 
-To minimize the chance of permissions errors, you can configure npm to use a different directory. In this example, you will create and use hidden directory in your home directory.
+To minimize the chance of permissions errors, you can configure npm to use a different directory. In this example, you will create and use a hidden directory in your home directory.
 
-1. Back up your computer.
-
-2. On the command line, in your home directory, create a directory for global installations:
+1. Configure npm to use the new directory path:
 
    ```
-   mkdir -p ~/.npm-global/lib
+   npm config set prefix ~/.local
    ```
 
-3. Configure npm to use the new directory path:
+2. In your preferred text editor, open or create a `~/.profile` file and add this line:
 
    ```
-   npm config set prefix ~/.npm-global
+   PATH=~/.local/bin:$PATH
    ```
 
-4. In your preferred text editor, open or create a `~/.profile` file and add this line:
-
-   ```
-   export PATH=~/.npm-global/bin:$PATH
-   ```
-
-5. On the command line, update your system variables:
+   If you are using zsh (which you can find out by running `echo $0`), you will also need to add this line to `~/.zprofile`:
 
    ```
    source ~/.profile
    ```
 
-6. To test your new configuration, install a package globally without using `sudo`:
+3. On the command line, update your system variables:
 
    ```
-   npm install -g jshint
+   source ~/.profile
    ```
 
-Instead of steps 3-5, you can use the corresponding ENV variable (e.g. if you don't want to modify `~/.profile`):
+4. To test your new configuration, install a package globally without using `sudo`:
 
-```
-NPM_CONFIG_PREFIX=~/.npm-global
-```
+   ```
+   npm install -g npm-check-updates
+   ```
+
+   And run it:
+
+   ```
+   ncu -g
+   ```
 
 <Note>
 


### PR DESCRIPTION
Simplify the steps a bit:

- Backing up the computer and creating the directory is not necessary, since it's created automatically  by npm.
- Use the ~/.local directory which is the standard place for user-specific software, and likely to already be in the user's PATH.
- `export` is not needed since PATH is already exported.
- Add a note for zsh which doesn't use ~/.profile.
- Use a different package as an example, since jshint is not regularly updated, and linters should generally be in `devDependencies` and used through npm scripts.
- Ensure the user can run the installed tool.
- Remove mention of `NPM_CONFIG_PREFIX` which is not sufficient, since the PATH still needs to be updated to use global tools.