### PR TITLE
fix: add missing color mapping for token string in colorMap

### DIFF
--- a/src/mdx/code.js
+++ b/src/mdx/code.js
@@ -49,6 +49,7 @@ const colorMap = {
   'token function': '#cf3846',
   'token parameter variable': '#277d7b',
   'token assign-left variable': '#277d7b',
+  'token string': '#db1068'
 }
 
 const MonoText = props => <Text sx={{fontFamily: 'mono', fontSize: 1}} {...props} />


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
