### PR TITLE
Add line about `workflow_call`

### DIFF
--- a/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
+++ b/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
@@ -278,6 +278,8 @@ If your package has private dependencies and `npm install` or `npm ci` is failin
 
 For packages in private repositories, provenance will not be generated even though you're using trusted publishing. This is a [known limitation](https://github.blog/changelog/2023-07-25-publishing-with-npm-provenance-from-private-source-repositories-is-no-longer-supported/) that applies regardless of whether your package itself is public or private.
 
+When using GitHub Actions, some users run the actual `npm publish` command via `workflow_call` — i.e., a workflow calls another workflow that contains the `npm publish` command. As a result, workflow-name validation is performed against the calling (parent) workflow that was executed, not the called (callee) workflow.
+
 ## Limitations and future improvements
 
 Trusted publishing currently supports only cloud-hosted runners. Support for self-hosted runners is intended for a future release. Each package can only have one trusted publisher configured at a time, though you can update this configuration as needed.


### PR DESCRIPTION
Describe how `workflow_call` works within trusted publishing.