### PR TITLE
Document npmjs.com markdown rendering specifics

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/about-package-readme-files.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/about-package-readme-files.mdx
@@ -2,7 +2,7 @@
 title: About package README files
 ---
 
-We highly recommend including a `README.md` file in your package directory as it helps developers find your package on npm and have a good experience using your code in their projects. In most cases `README.md` files include directions for _installing_, _configuring_, and _using_ the code in your package; as well as any other information a user may find helpful. Just like in any GitHub repository, the `README.md` file will be rendered on the package's page.
+We highly recommend including a `README.md` file in your package directory as it helps developers find your package on npm and have a good experience using your code in their projects. In most cases `README.md` files include directions for _installing_, _configuring_, and _using_ the code in your package; as well as any other information a user may find helpful. Just like in any GitHub repository, the `README.md` file will be rendered on the package's page. On [npmjs.com](https://www.npmjs.com/), the `README.md` is rendered as [GitHub Flavored Markdown](https://github.github.com/gfm/) via [GitHub's API](https://docs.github.com/en/rest/markdown/markdown).
 
 An npm package `README.md` file **must** be in the root-level directory of the package.
 


### PR DESCRIPTION
Edit [the "About package README files" page](https://docs.npmjs.com/about-package-readme-files) to mention that [GitHub Flavored Markdown](https://github.github.com/gfm/) is rendered on npmjs.com.

Here's what the page looks like after these changes:

<img width="823" height="867" alt="Screenshot 2025-10-06 at 6 55 27 AM" src="https://github.com/user-attachments/assets/5f8843fd-a699-4619-895c-814a262c6424" />

## References
Closes #1734