### PR TITLE
[Fix Accessibility]: Add tabIndex to VariantItem for improved accessibility

### DIFF
--- a/src/components/variant-select.js
+++ b/src/components/variant-select.js
@@ -16,7 +16,7 @@ const StyledOverlay = styled(ActionMenu.Overlay)`
 
 const VariantItem = ({title, shortName, url, active}) => {
   return (
-    <ActionList.Item state={{scrollUpdate: false}} id={shortName} active={active}>
+    <ActionList.Item state={{scrollUpdate: false}} id={shortName} active={active} tabIndex={null}>
       <LinkNoUnderline to={url}>{title}</LinkNoUnderline>
     </ActionList.Item>
   )


### PR DESCRIPTION
- Keyboard focus order is not logical for the list items under 'Select CLI Version' button. keyboard focus is moving twice upon the version list items.

https://github.com/user-attachments/assets/e3306e28-11ae-48be-b115-17c4ddabf62e



