### PR TITLE
Remove `registry-url` input when setting up GitHub Actions as a trusted publisher

### DIFF
--- a/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
+++ b/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
@@ -92,7 +92,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm


### PR DESCRIPTION
This input causes a dummy `NODE_AUTH_TOKEN` to be exported to the environment in later steps. If this variable is present then OIDC token exchange fails.

## References
https://github.com/actions/setup-node/blob/2028fbc5c25fe9cf00d9f06a71cc4710d4507903/src/authutil.ts#L55-L58
