### PR TITLE
Clarify node-version requirement in trusted-publishers.mdx

### DIFF
--- a/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
+++ b/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20' # Required or `npm install -g npm@latest` will fail with permission error
           registry-url: 'https://registry.npmjs.org'
 
       # Ensure npm 11.5.1 or later is installed


### PR DESCRIPTION
Added comment to clarify node-version requirement.

```
Run npm install -g npm@latest
npm error code EACCES
npm error syscall mkdir
npm error path /usr/local/share/man/man5
npm error errno -13
npm error Error: EACCES: permission denied, mkdir '/usr/local/share/man/man5'
npm error     at async mkdir (node:internal/fs/promises:858:10)
npm error     at async Promise.all (index 0)
npm error     at async Promise.all (index 1)
npm error     at async #createBinLinks (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:394:5)
npm error     at async Promise.allSettled (index 0)
npm error     at async #linkAllBins (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:375:5)
npm error     at async #build (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:160:7)
npm error     at async Arborist.rebuild (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js:62:5)
npm error     at async [reifyPackages] (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:325:11)
npm error     at async Arborist.reify (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:142:5) {
npm error   errno: -13,
npm error   code: 'EACCES',
npm error   syscall: 'mkdir',
npm error   path: '/usr/local/share/man/man5'
npm error }
npm error
npm error The operation was rejected by your operating system.
npm error It is likely you do not have the permissions to access this file as the current user
npm error
npm error If you believe this might be a permissions issue, please double-check the
npm error permissions of the file and its containing directories, or try running
npm error the command again as root/Administrator.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-10-28T15_30_01_678Z-debug-0.log
Error: Process completed with exit code 243.
```