### PR TITLE
Maintain the example along with the paths

### DIFF
--- a/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-scoped-public-packages.mdx
+++ b/content/packages-and-modules/contributing-packages-to-the-registry/creating-and-publishing-scoped-public-packages.mdx
@@ -70,7 +70,7 @@ For less sensitive information, such as testing data, use a `.npmignore` or `.gi
 To reduce the chances of publishing bugs, we recommend testing your package before publishing it to the npm registry. To test your package, run `npm install` with the full path to your package directory:
 
 ```
-npm install my-package
+npm install /path/to/my-test-package
 ```
 
 ## Publishing scoped public packages
@@ -80,7 +80,7 @@ By default, scoped packages are published with private visibility. To publish a 
 1. On the command line, navigate to the root directory of your package.
 
    ```
-   cd /path/to/package
+   cd /path/to/my-test-package
    ```
 
 2. To publish your scoped public package to the npm registry, run:


### PR DESCRIPTION
<!-- What / Why -->
### Why?
The current examples are clear, it could be helpful to maintain a constant name for the paths to the hypothetical package, on any of the installation and directory navigation examples.

### Description
<!-- Describe the request in detail. What it does and why it's being changed. -->
Simple suggestion for changing command line examples in the **Test your package** and **Publishing your scoped public packages**
