### PR TITLE
[docs] Remove classic token description

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
+++ b/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
@@ -22,29 +22,10 @@ You can work with tokens from the web or the CLI, whichever is easiest. What you
 npm token commands let you:
 
 - View tokens for easier tracking and management
-- Create new legacy tokens (deprecated)
 - Limit access according to IP address ranges (CIDR)
 - Delete/revoke tokens
 
 For more information on creating and viewing access tokens on the web and CLI, see "[Creating and viewing access tokens][create-token]".
-
-## About legacy tokens (Deprecated)
-
-<Note variant="danger">
-
-**Warning:** Legacy access tokens were removed on November 5, 2025.
-
-</Note>
-
-Legacy tokens are created with the same permissions as the user who created them. The npm CLI automatically generates and uses a publish token when you run `npm login`.
-
-There are three different types of legacy tokens:
-
-- **Read-only**: You can use these tokens to download packages from the registry. These tokens are best for automation and workflows where you are installing packages. For greater security, we recommend using [granular access tokens](#about-granular-access-tokens) instead.
-- **Automation**: You can use these tokens to download packages and install new ones. These tokens are best for automation workflows where you are publishing new packages. Automation tokens do not 2FA for executing operations on npm and are suitable for CI/CD workflows. For greater security, we recommend using [granular access tokens](#about-granular-access-tokens) instead.
-- **Publish**: You can use these tokens to download packages, install packages, and update user and package settings. We recommend using them for interactive workflows such as a CLI. If 2FA is enabled on your account, publish tokens will require 2FA to execute sensitive operations on npm.
-
-Legacy tokens do not have an expiration date. It is important to be aware of your tokens and keep them protected for account security. For more information, see "[Securing your token][secure-token]."
 
 ## About granular access tokens
 


### PR DESCRIPTION
This PR removes description about legacy tokens as we are removing them permanently.