### PR TITLE
Add provenance to GitLab OIDC example

### DIFF
--- a/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
+++ b/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
@@ -131,6 +131,8 @@ publish:
   id_tokens:
     NPM_ID_TOKEN:
       aud: "npm:registry.npmjs.org"
+    SIGSTORE_ID_TOKEN:
+      aud: sigstore
   script:
     # Ensure npm 11.5.1 or later is installed
     - npm install -g npm@latest


### PR DESCRIPTION
The GitLab OIDC example was missing the `SIGSTORE_ID_TOKEN`, which is needed for publishing provenance, also with OIDC.

## References

Closes https://github.com/npm/cli/issues/8558