### PR TITLE
Add `sudo` to npm upgrade command in example

### DIFF
--- a/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
+++ b/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
@@ -96,7 +96,7 @@ jobs:
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
## Description
The example doesn't work as written. According to this issue, it's because you need to use `sudo`: https://github.com/actions/setup-node/issues/324#issuecomment-970306807

This implements that.

## Changes
* Add `sudo` to npm upgrade command

## Testing
Review. See that you can run this workflow successfully.