### PR TITLE
Update and rename disputes policy to align with GitHub's Username Policy

### DIFF
--- a/content/policies/disputes.mdx
+++ b/content/policies/disputes.mdx
@@ -1,36 +1,13 @@
 ---
-title: Dispute Resolution
+title: Username Policy
 edit_on_github: false
 ---
 
-This document describes the steps that you should take to resolve naming disputes with other npm publishers. It also describes the steps you should take if you think a name [infringes your trademark](#trademarks).
-
-This document is additive to the guidelines in the [npm Code of Conduct][conduct] and [npm Open-Source terms][open-source-terms]. Nothing in this document should be interpreted to contradict any aspect of the npm Code of Conduct or Open-Source Terms.
-
 ## tl;dr
 
-1. Open a support ticket at [https://support.github.com/contact/npm-name-disputes](https://support.github.com/contact/npm-name-disputes).
-1. Fill out the form with as much detail as possible.
-1. Support will address your request. Please note submitting a report does not guarantee the transfer of a package, org, or username.
+npm follows GitHub’s [Username Policy](https://docs.github.com/en/site-policy/other-site-policies/github-username-policy). This means that usernames, organization names, and package names are available on a first-come, first-served basis, and are intended for immediate and active use.
 
-## When to use this process
-
-This process is an excellent way to:
-
-- Request a name that you believe is currently misleading or could be confused with a name used by your company or open source project
-- Request a name related to your company or open source project that cannot be claimed via account recovery
-
-This process does not apply if the package violates our [Terms of Use][open-source-terms], in particular our [Acceptable Use][acceptable-use] and [Acceptable Content][acceptable-content] rules, or our [Code of Conduct][conduct]. Those documents refer to this one to resolve cases of "squatting"; see below.
-
-If you see bad behavior or content you believe is unacceptable, refer to the Code of Conduct for guidelines on [reporting violations][violations]. **You are never expected to resolve abusive behavior on your own.** **We are here to help.**
-
-## When not to use this process
-
-This process is not available for dispute requests due to lack of activity related to a specific name.
-
-Please also note there are cases where a party may have claim to a specific name, but giving that name to the requesting party would pose a supply-chain risk to the npm ecosystem. In such cases, requests may be denied independent of the validity of the claim.
-
-## Trademarks
+### Trademarks
 
 npm processes Trademark claims under GitHub's [Trademark Policy](https://docs.github.com/site-policy/content-removal-policies/github-trademark-policy).
 
@@ -38,17 +15,11 @@ If you think another npm publisher is infringing your trademark, such as by usin
 
 Use of npm's own trademarks is covered by our [Logo and Usage Policy][logos-and-usage].
 
-## Changes
-
-This is a living document and may be updated from time to time. Please refer to the [git history for this document](https://github.com/npm/documentation/blob/main/content/policies/disputes.mdx) to view the changes.
-
-## Definitions
-
 ### Squatting
 
-It is against npm's [Terms of Use][acceptable-content] to publish a package, register a user name or an organization name simply for the purposes of reserving it for future use.
+It is against npm's [Terms of Use][acceptable-content] to publish a package, register a username or an organization name simply for the purposes of reserving it for future use. Accounts violating the name squatting policy may be removed or renamed without notice. Attempts to sell, buy, or solicit other forms of payment in exchange for account names are prohibited and may result in permanent account suspension.
 
-We do not pro-actively scan the registry for squatted packages, so the fact that a name is in use does not mean we consider it valid. The standards for what we consider squatting depend on what is being squatted:
+The standards for what we consider squatting depend on what is being squatted:
 
 #### Packages
 
@@ -58,9 +29,9 @@ Package names are considered squatted if the package has no genuine function.
 
 Organization names are considered squatted if there are no packages published within a reasonable time. If an organization is a paid organization, it may have private packages that are invisible to third parties. For privacy reasons, we cannot reveal whether or not an organization has private packages, so a paid organization will never be considered squatted.
 
-#### User names
+#### Usernames
 
-We are extremely unlikely to transfer control of a user name, as it is totally valid to be an npm user and never publish any packages: for instance, you might be part of an organization or need read-only access to private packages.
+We are extremely unlikely to transfer control of a username, as it is totally valid to be an npm user and never publish any packages: for instance, you might be part of an organization or need read-only access to private packages.
 
 ## License
 


### PR DESCRIPTION
GitHub has updated its trademark policy to accommodate npm reports. Therefore, we're updating npm's dispute policy to align fully with GitHub's Username and Trademark policies.