### PR TITLE
docs: add import syntax with module example

### DIFF
--- a/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
+++ b/content/packages-and-modules/introduction-to-packages-and-modules/about-packages-and-modules.mdx
@@ -50,7 +50,7 @@ To be loaded by the Node.js `require()` function, a module must be one of the fo
 - A folder with a `package.json` file containing a `"main"` field.
 - A JavaScript file.
 
-To use the `import` syntax, a module also must also include `"type": "module"` in its `package.json` file:
+To use the `import` syntax, a module should also include `"type": "module"` in its `package.json` file:
 
 ```json
 {


### PR DESCRIPTION
Specify `import` alongside `require()` syntax