### PR TITLE
docs: clarify trusted publishing Node/npm versions...

### DIFF
--- a/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
+++ b/content/packages-and-modules/securing-your-code/trusted-publishers.mdx
@@ -141,7 +141,7 @@ The `id_tokens` configuration tells GitLab to generate an OIDC token for npm. Le
 
 ### Managing trusted publisher configurations
 
-You can modify or remove your trusted publisher configuration at any time through your package settings on [npmjs.com](https://npmjs.com) → Packages → <your-package> → Settings → Trusted publishing. Each package can only have one trusted publisher connection at a time, but this connection can be edited or deleted as needed. To change providers (for example, switching from GitHub Actions to GitLab CI/CD), simply edit your existing configuration and select the new provider. The change takes effect immediately for future publishes. To remove trusted publishing entirely and return to token-based authentication, delete the trusted publisher configuration from your package settings.
+You can modify or remove your trusted publisher configuration at any time through your package settings on [npmjs.com](https://npmjs.com) → Packages → YOUR_PACKAGE → Settings → Trusted publishing. Each package can only have one trusted publisher connection at a time, but this connection can be edited or deleted as needed. To change providers (for example, switching from GitHub Actions to GitLab CI/CD), simply edit your existing configuration and select the new provider. The change takes effect immediately for future publishes. To remove trusted publishing entirely and return to token-based authentication, delete the trusted publisher configuration from your package settings.
 
 ## Recommended: Restrict token access when using trusted publishers
 


### PR DESCRIPTION

<!-- What / Why -->
This PR improves the documentation for trusted publishing with OIDC in GitHub Actions. 
It clarifies the required Node/npm CLI versions, shows where to find the Trusted Publishing settings 
in the npm UI via breadcrumbs, and adds guidance on where to seek immediate help for issues. These changes aim to reduce friction and make key information easier for users to find.

## References
Related to [npm/cli issue #8884](https://github.com/npm/cli/issues/8884)

