### PR TITLE
feat: improve search relevance by indexing headings and removing location penalty

### DIFF
--- a/src/hooks/__tests__/use-search.test.js
+++ b/src/hooks/__tests__/use-search.test.js
@@ -1,0 +1,47 @@
+import {flattenHeadings} from '../use-search'
+
+describe('flattenHeadings', () => {
+  test('returns empty array for null/undefined input', () => {
+    expect(flattenHeadings(null)).toEqual([])
+    expect(flattenHeadings(undefined)).toEqual([])
+  })
+
+  test('returns empty array for empty items', () => {
+    expect(flattenHeadings([])).toEqual([])
+  })
+
+  test('flattens single level of headings', () => {
+    const items = [{title: 'Description'}, {title: 'Configuration'}]
+    expect(flattenHeadings(items)).toEqual(['Description', 'Configuration'])
+  })
+
+  test('flattens nested headings', () => {
+    const items = [
+      {
+        title: 'Description',
+        items: [{title: 'before'}, {title: 'min-release-age'}],
+      },
+    ]
+    expect(flattenHeadings(items)).toEqual(['Description', 'before', 'min-release-age'])
+  })
+
+  test('flattens deeply nested headings', () => {
+    const items = [
+      {
+        title: 'Top',
+        items: [
+          {
+            title: 'Mid',
+            items: [{title: 'Deep'}],
+          },
+        ],
+      },
+    ]
+    expect(flattenHeadings(items)).toEqual(['Top', 'Mid', 'Deep'])
+  })
+
+  test('skips items without a title', () => {
+    const items = [{items: [{title: 'child'}]}, {title: 'sibling'}]
+    expect(flattenHeadings(items)).toEqual(['child', 'sibling'])
+  })
+})

--- a/src/hooks/use-search.js
+++ b/src/hooks/use-search.js
@@ -6,6 +6,15 @@ import usePage from './use-page'
 import * as getNav from '../util/get-nav'
 import {CLI_PATH} from '../constants'
 
+export const flattenHeadings = items => {
+  if (!items) return []
+  return items.reduce((acc, item) => {
+    if (item.title) acc.push(item.title)
+    if (item.items) acc.push(...flattenHeadings(item.items))
+    return acc
+  }, [])
+}
+
 const useSearchData = () => {
   const data = useStaticQuery(graphql`
     {
@@ -15,6 +24,7 @@ const useSearchData = () => {
           frontmatter {
             title
           }
+          tableOfContents
           body
         }
       }
@@ -40,6 +50,7 @@ const useSearchData = () => {
         return {
           path: node.path,
           title: mdxNode.frontmatter.title,
+          headings: flattenHeadings(mdxNode.tableOfContents?.items).join(' '),
           body: mdxNode.body,
         }
       })

--- a/src/util/search.worker.js
+++ b/src/util/search.worker.js
@@ -36,7 +36,14 @@ class Fuse {
     const items = this.allItems.filter(item =>
       item.path.startsWith(this.cliVersion.root) ? item.path.startsWith(this.cliVersion.current) : true,
     )
-    this.instances.set(this.cliVersion.current, new FuseJs(items, {threshold: 0.2, keys: ['title', 'body']}))
+    this.instances.set(
+      this.cliVersion.current,
+      new FuseJs(items, {
+        threshold: 0.2,
+        ignoreLocation: true,
+        keys: ['title', 'headings', 'body'],
+      }),
+    )
   }
 
   setItems(items) {


### PR DESCRIPTION
### Summary
Improves search by indexing page headings and removing the Fuse.js location-based scoring penalty.

### Changes
- Extract headings from tableOfContents and add as a searchable headings field
- Set ignoreLocation: true so matches anywhere in a document are scored equally
- Add unit tests for the new flattenHeadings helper

### Why
By default, Fuse.js penalizes matches far from position 0. For long body fields, this makes most content effectively unsearchable. Even exact matches deep in a page can get filtered out. Adding headings as a searchable field further improves discoverability of section-level content.

