### PR TITLE
fix: run prettier on full assembled output in cli transform

### DIFF
--- a/cli/lib/transform.js
+++ b/cli/lib/transform.js
@@ -128,10 +128,11 @@ const transform = (data, {release, path, frontmatter, format = s => s}) => {
   // then do any transformer specific replacements
   body = format(body)
 
-  // prettier again now that we've altered the contents
-  body = prettierFormat(body)
+  // then do any transformer specific replacements
+  body = format(body)
 
-  return `---\n${yaml.stringify(attributes).trim()}\n---\n\n${body}`
+  // prettier on the final assembled output so the committed file passes prettier --check
+  return prettierFormat(`---\n${yaml.stringify(attributes).trim()}\n---\n\n${body}`)
 }
 
 // copied from minipass-collect. collects all chunks into a single


### PR DESCRIPTION
## Problem

The cli transform runs prettier on the markdown body, then reassembles the file with frontmatter. The final composed output is never run through prettier as a complete document. This means auto-generated files can fail `prettier --check` in CI — as seen with `npm-stage.mdx`.

## Fix

Run prettier on the final assembled output (frontmatter + body) instead of just the body. This ensures every generated `.mdx` file passes `prettier --check`.