### PR TITLE
fix: improve search input text contrast accessibility

### DIFF
--- a/content/cli/v11/commands/npm-stage.mdx
+++ b/content/cli/v11/commands/npm-stage.mdx
@@ -77,14 +77,14 @@ Before using `npm stage` commands, ensure the following requirements are met:
 
 ### 2FA Requirements by Subcommand
 
-| Command | Requires 2FA | Notes |
-| --- | --- | --- |
-| `npm stage publish` | No | Designed for automated workflows; defers 2FA to approval |
-| `npm stage list` | No | View staged packages |
-| `npm stage view` | No | View staged package details |
-| `npm stage approve` | Yes | Prompts for 2FA to publish the staged package |
-| `npm stage reject` | Yes | Prompts for 2FA to permanently remove the staged package |
-| `npm stage download` | No | Downloads the tarball for local inspection |
+| Command              | Requires 2FA | Notes                                                    |
+| -------------------- | ------------ | -------------------------------------------------------- |
+| `npm stage publish`  | No           | Designed for automated workflows; defers 2FA to approval |
+| `npm stage list`     | No           | View staged packages                                     |
+| `npm stage view`     | No           | View staged package details                              |
+| `npm stage approve`  | Yes          | Prompts for 2FA to publish the staged package            |
+| `npm stage reject`   | Yes          | Prompts for 2FA to permanently remove the staged package |
+| `npm stage download` | No           | Downloads the tarball for local inspection               |
 
 ### Tag Behavior
 
@@ -96,12 +96,12 @@ The tag is an immutable property of the staged package. Once a package is staged
 
 The key difference with staged publishing is that `npm stage publish` never requires a 2FA prompt, regardless of token type. This is what makes it suitable for automated workflows. The goal of `npm stage publish` is deferring proof-of-presence to a later point in time.
 
-| Token Type | `npm stage publish` | `npm publish` |
-| --- | --- | --- |
-| GAT with bypass | Can stage | Can publish (if allowed by package publishing access) |
-| GAT without bypass | Can stage | 2FA prompt (if allowed by package publishing access) |
-| Session token | Can stage | 2FA prompt |
-| Trust token (OIDC) | Can stage (if allowed) | Can publish (if allowed) |
+| Token Type         | `npm stage publish`    | `npm publish`                                         |
+| ------------------ | ---------------------- | ----------------------------------------------------- |
+| GAT with bypass    | Can stage              | Can publish (if allowed by package publishing access) |
+| GAT without bypass | Can stage              | 2FA prompt (if allowed by package publishing access)  |
+| Session token      | Can stage              | 2FA prompt                                            |
+| Trust token (OIDC) | Can stage (if allowed) | Can publish (if allowed)                              |
 
 ### Trust Relationship Permissions
 

--- a/src/components/text-input.js
+++ b/src/components/text-input.js
@@ -8,12 +8,13 @@ const TextInput = styled(PrimerTextInput)`
    */
   input {
     font-size: 16px !important;
-    color: rgb(225, 228, 232) !important;
+    color: var(--fgColor-default, #1f2328) !important;
+    caret-color: var(--fgColor-default, #1f2328) !important;
   }
 
   input::placeholder {
-    color: rgb(225, 228, 232) !important;
-    opacity: 0.7;
+    color: var(--fgColor-muted, #57606a) !important;
+    opacity: 1;
   }
 `
 export default TextInput


### PR DESCRIPTION
## Summary
- Fix search input text visibility by replacing hardcoded low-contrast input text color with Primer foreground tokens and fallbacks in src/components/text-input.js
- Ensure caret visibility by setting caret-color to the same accessible foreground token
- Improve placeholder readability with muted foreground token fallback and remove opacity fade
- Include required docs formatting update from CI in content/cli/v11/commands/npm-stage.mdx (Prettier only)

## Why
- Typed text in the search box could be effectively invisible on light backgrounds, causing an accessibility issue.

## Validation
- npx eslint src/components/text-input.js
- npx prettier --check content/cli/v11/commands/npm-stage.mdx
