### PR TITLE
feat: preparation for v12

### DIFF
--- a/cli/releases.json
+++ b/cli/releases.json
@@ -13,6 +13,10 @@
   },
   {
     "id": "v11",
+    "branch": "release/v11"
+  },
+  {
+    "id": "v12",
     "branch": "latest"
   }
 ]


### PR DESCRIPTION
## Situation

[npm@12.0.0](https://github.com/npm/cli/releases/tag/v12.0.0) was released, but no CLI documentation was generated for v12 (see npm/cli#9742). https://docs.npmjs.com/cli still redirects to v11.

## Root cause

The nightly **Update CLI** workflow only runs `npm run build -w cli`, which reads the manually-maintained `cli/releases.json`. That file had no `v12` entry, so `build.js` never matched `npm@12.x` to a release and generated nothing. Additionally `v11` still pointed at the `latest` branch, which now tracks v12 in npm/cli.

## Change

Repoint `v11` to its new `release/v11` branch and add a `v12` entry on `latest`, mirroring the previous major preparations ("Update CLI releases for npm 10" and #1402 "preparation for v11").

Adding the new `v12` key triggers the build's cache-voiding (`voidOnNewKey`), which resets v11 to `legacy` and regenerates the nav. After merge, the nightly `update-cli` job (or a manual `workflow_dispatch`) will build and publish the v12 docs.

Fixes npm/cli#9742