### PR TITLE
docs: fix neither/nor usage

### DIFF
--- a/content/cli/v10/configuring-npm/package-json.mdx
+++ b/content/cli/v10/configuring-npm/package-json.mdx
@@ -544,7 +544,7 @@ Git URLs are of the form:
 
 `<protocol>` is one of `git`, `git+ssh`, `git+http`, `git+https`, or `git+file`.
 
-If `#<commit-ish>` is provided, it will be used to clone exactly that commit. If the commit-ish has the format `#semver:<semver>`, `<semver>` can be any valid semver range or exact version, and npm will look for any tags or refs matching that range in the remote repository, much as it would for a registry dependency. If neither `#<commit-ish>` or `#semver:<semver>` is specified, then the default branch is used.
+If `#<commit-ish>` is provided, it will be used to clone exactly that commit. If the commit-ish has the format `#semver:<semver>`, `<semver>` can be any valid semver range or exact version, and npm will look for any tags or refs matching that range in the remote repository, much as it would for a registry dependency. If neither `#<commit-ish>` nor `#semver:<semver>` is specified, then the default branch is used.
 
 Examples:
 


### PR DESCRIPTION
## Description

Fixes the use of `or` after `neither` in the documentation.

Changes `neither ... or ...` to `neither ... nor ...` for grammatical correctness.