### PR TITLE
feat(tokens): document stage-only access tokens

### DIFF
--- a/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
+++ b/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
@@ -35,7 +35,7 @@ Granular access tokens allow you to restrict access provided to the token based 
 - Grant tokens access to specific organizations
 - Set a token expiration date
 - Limit token access based on IP address ranges
-- Select between **read-only** or **read and write** access. For packages and scopes, **read and write** access can either **publish and stage** new versions or be **stage only** (see "[About stage-only tokens](#about-stage-only-tokens)")
+- Select between **Read-only** or **Read and write** access. For packages and scopes, **Read and write** access can either **publish and stage** new versions or be **stage only** (see "[About stage-only tokens](#about-stage-only-tokens)").
 - Configure a token to **Bypass 2FA** requirements
 
 You can create up to 1000 granular access tokens on your npm account. You can set how long your token is valid for, at least one day in the future. Each token can access up to 50 organizations, and up to either 50 packages, 50 scopes, or a combination of 50 packages and scopes. Access tokens are tied to users’ permission; hence it cannot have more permission than the user at any point in time. If a user has their access revoked from a package or an org., their granular access token will also have its access revoked from those packages or org.
@@ -51,7 +51,7 @@ When a granular access token has **Read and write** access to packages and scope
 - **Read and write (publish and stage)**: the token can publish new package versions directly to the registry.
 - **Read and write (stage only)**: the token _cannot_ publish new package versions directly. Instead, it stages a version for a package maintainer to review and promote.
 
-Stage-only tokens are a safer on-ramp for automation such as continuous integration and deployment (CI/CD). Because promoting a staged version always requires a maintainer with two-factor authentication (2FA), a leaked or misused stage-only token cannot push a new version live on its own.
+Stage-only tokens are a safer on-ramp for automation such as continuous integration and deployment (CI/CD). Because a stage-only token can't publish a new version directly — each staged version must be reviewed and promoted by a maintainer with two-factor authentication (2FA) — a leaked or misused token can't get a new version onto the registry without that maintainer approval. This narrows the risk of direct publishing; it does not otherwise restrict the token's write capabilities.
 
 A stage-only token **can**:
 
@@ -80,7 +80,7 @@ When you publish a new version with a stage-only token, the registry does not pu
 
 #### Direct publishing is being deprecated
 
-Direct-publish tokens are being deprecated. The ability to publish new package versions directly with a granular access token will be removed in **January 2027**. To prepare, switch automation that publishes new versions to a **Read and write (stage only)** token together with the staging workflow described above. See also "[Account-identity actions require an interactive 2FA challenge](#account-identity-actions-require-an-interactive-2fa-challenge)" for related changes to bypass-2FA tokens.
+Bypass-2FA tokens with direct-publish access are being deprecated. The ability to publish new package versions directly with a granular access token will be removed in **January 2027**. To prepare, switch automation that publishes new versions to a **Read and write (stage only)** token together with the staging workflow described above. See also "[Account-identity actions require an interactive 2FA challenge](#account-identity-actions-require-an-interactive-2fa-challenge)" for related changes to bypass-2FA tokens.
 
 ### Account-identity actions require an interactive 2FA challenge
 

--- a/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
+++ b/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
@@ -35,7 +35,7 @@ Granular access tokens allow you to restrict access provided to the token based 
 - Grant tokens access to specific organizations
 - Set a token expiration date
 - Limit token access based on IP address ranges
-- Select between **read-only** or **read and write** access
+- Select between **read-only** or **read and write** access. For packages and scopes, **read and write** access can either **publish and stage** new versions or be **stage only** (see "[About stage-only tokens](#about-stage-only-tokens)")
 - Configure a token to **Bypass 2FA** requirements
 
 You can create up to 1000 granular access tokens on your npm account. You can set how long your token is valid for, at least one day in the future. Each token can access up to 50 organizations, and up to either 50 packages, 50 scopes, or a combination of 50 packages and scopes. Access tokens are tied to users’ permission; hence it cannot have more permission than the user at any point in time. If a user has their access revoked from a package or an org., their granular access token will also have its access revoked from those packages or org.
@@ -43,6 +43,44 @@ You can create up to 1000 granular access tokens on your npm account. You can se
 When you give a token access to an organization, the token can only be used for managing organization settings and teams or users associated with the organization. It does not give the token the right to publish packages managed by the organization.
 
 The Bypass 2FA capability applies to tokens with write access and is set to false by default at token creation. When the Bypass 2FA option is set to true, this setting takes precedence over account-level and package-level 2FA settings for package and automation actions such as publishing. This means that even if account-level 2FA is enabled and/or package-level 2FA is required, 2FA will still be bypassed when using the token to publish. Do not set Bypass 2FA to true if a package or organization requires fully enforced 2FA.
+
+### About stage-only tokens
+
+When a granular access token has **Read and write** access to packages and scopes, you can choose how it is allowed to publish:
+
+- **Read and write (publish and stage)**: the token can publish new package versions directly to the registry.
+- **Read and write (stage only)**: the token _cannot_ publish new package versions directly. Instead, it stages a version for a package maintainer to review and promote.
+
+Stage-only tokens are a safer on-ramp for automation such as continuous integration and deployment (CI/CD). Because promoting a staged version always requires a maintainer with two-factor authentication (2FA), a leaked or misused stage-only token cannot push a new version live on its own.
+
+A stage-only token **can**:
+
+- Stage a new package version for review, using `npm stage publish`
+- Deprecate package versions
+- Move dist-tags
+- Unpublish package versions
+
+A stage-only token **cannot**:
+
+- Publish a new package version directly. Attempting to publish a new version fails with the error `E_STAGE_REQUIRED`.
+
+<Note>
+
+**Note:** Stage-only restricts _direct publishing of new versions only_. It is not a general-purpose security boundary — a stage-only token retains the other write capabilities listed above, so treat it with the same care as any other token.
+
+</Note>
+
+#### Publishing with a stage-only token
+
+When you publish a new version with a stage-only token, the registry does not publish it immediately. Instead:
+
+1. **Stage the version.** In your automation or CLI, run `npm stage publish` instead of `npm publish`. This uploads the version and creates a stage that is not yet live. If you run `npm publish` with a stage-only token, the publish is rejected with an `E_STAGE_REQUIRED` error telling you to run `npm stage publish` and have the version approved.
+2. **Review the stage.** A maintainer can list pending stages with `npm stage list` and inspect one with `npm stage view <stage-id>` or `npm stage download <stage-id>`.
+3. **Promote the version.** A maintainer with 2FA enabled promotes the staged version to the registry with `npm stage approve <stage-id> --otp <code>`, or discards it with `npm stage reject <stage-id>`.
+
+#### Direct publishing is being deprecated
+
+Direct-publish tokens are being deprecated. The ability to publish new package versions directly with a granular access token will be removed in **January 2027**. To prepare, switch automation that publishes new versions to a **Read and write (stage only)** token together with the staging workflow described above. See also "[Account-identity actions require an interactive 2FA challenge](#account-identity-actions-require-an-interactive-2fa-challenge)" for related changes to bypass-2FA tokens.
 
 ### Account-identity actions require an interactive 2FA challenge
 

--- a/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
+++ b/content/integrations/integrating-npm-with-external-services/about-access-tokens.mdx
@@ -58,7 +58,6 @@ A stage-only token **can**:
 - Stage a new package version for review, using `npm stage publish`
 - Deprecate package versions
 - Move dist-tags
-- Unpublish package versions
 
 A stage-only token **cannot**:
 

--- a/content/integrations/integrating-npm-with-external-services/creating-and-viewing-access-tokens.mdx
+++ b/content/integrations/integrating-npm-with-external-services/creating-and-viewing-access-tokens.mdx
@@ -32,7 +32,9 @@ You can [create](#creating-access-tokens) and [view](#viewing-access-tokens) acc
    <Screenshot src="/integrations/integrating-npm-with-external-services/granular-access-token-ip-range.png" alt="Screenshot of the allowed IP ranges section" />
 
 7. (Optional) In the **Packages and scopes** section, configure your token's access to packages and scopes.
-   - In the **Permissions** dropdown menu, select **No access**, **Read-only**, or **Read and write**.
+   - In the **Permissions** dropdown menu, select **No access**, **Read-only**, **Read and write (publish and stage)**, or **Read and write (stage only)**.
+     - **Read and write (publish and stage)** lets the token publish new package versions directly to the registry.
+     - **Read and write (stage only)** lets the token stage new versions for a maintainer to review and promote, but not publish them directly. This is a safer option for automation such as CI/CD. For more information, see "[About stage-only tokens](/about-access-tokens#about-stage-only-tokens)."
    - Under **Select Packages**, select either:
      - **All Packages** to grant the token access to all packages the user account has access to.
      - **Only select packages and scopes** to choose up to 50 specific packages or scopes to give the token access to. Then select specific packages or scopes from the dropdown menu.


### PR DESCRIPTION
## What

Adds public documentation for the new **"Read and write (stage only)"** granular access token publish policy.

Part of github/npm#15530 (Phase 1 — safer stage-capable GAT). Closes github/npm#15610.

## Changes

**`about-access-tokens.mdx`** — new `### About stage-only tokens` section covering:
- What it is / why it exists (safer automation on-ramp).
- Capabilities **and** limitations: **can** stage (`npm stage publish`), deprecate, move dist-tags, unpublish; **cannot** directly publish a new version (fails with `E_STAGE_REQUIRED`).
- Promotion flow: `npm stage publish` → maintainer with 2FA runs `npm stage approve <stage-id> --otp <code>`.
- Jan 2027 direct-publish deprecation.
- A `<Note>` explicitly stating this is **not** a general-purpose security boundary (avoids overstating security, per the issue).

**`creating-and-viewing-access-tokens.mdx`** — updates the now-live **Packages and scopes** permission options to match the production UI (wubwub #3762, deployed at 100%): **Read and write (publish and stage)** / **Read and write (stage only)**.
